### PR TITLE
Add Wheel Odometry to Simulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ include_directories(
 )
 
 ## Declare a C++ library
-add_library(sensors lib/sensors/src/lidar.cpp lib/sensors/src/gps.cpp lib/sensors/src/inertialUnit.cpp)
+add_library(sensors lib/sensors/src/lidar.cpp lib/sensors/src/gps.cpp lib/sensors/src/inertialUnit.cpp lib/sensors/src/wheelOdometry.cpp)
 target_link_libraries(sensors ${WEBOTS_LIB} ${catkin_LIBRARIES})
 
 ## Declare a C++ executable

--- a/lib/sensors/include/sensors/wheelOdometry.hpp
+++ b/lib/sensors/include/sensors/wheelOdometry.hpp
@@ -1,0 +1,34 @@
+#include "ros/ros.h"
+#include "geometry_msgs/Twist.h"
+#include "webots/Motor.hpp"
+#include "webots/Supervisor.hpp"
+
+
+namespace AutomatED {
+
+class WheelOdometry {
+public:
+  WheelOdometry(webots::Supervisor *webots_supervisor,
+                ros::NodeHandle *ros_handle);
+  ~WheelOdometry();
+
+  void publishWheelOdometry();
+
+private:
+  // Handlers
+  webots::Supervisor *wb;
+  ros::NodeHandle *nh;
+
+  // Webots devices
+  webots::Motor *wheels[];
+
+  // ROS parameters
+  std::string wheel_names[];
+  int sampling_period;
+  std::string wheel_odometry_topic;
+
+  // ROS publisher
+  ros::Publisher wheel_odometry_pub;
+};
+
+}

--- a/lib/sensors/include/sensors/wheelOdometry.hpp
+++ b/lib/sensors/include/sensors/wheelOdometry.hpp
@@ -19,12 +19,13 @@ private:
   ros::NodeHandle *nh;
 
   // Webots devices
-  webots::Motor *wheels[];
+  webots::Motor *wheels[4];
 
   // ROS parameters
-  std::string wheel_names[];
   int sampling_period;
-  std::string wheel_odometry_topic;
+  std::string wheel_odometry_twist_topic;
+  double wheel_separation;
+  double wheel_radius;
 
   // ROS publisher
   ros::Publisher wheel_odometry_pub;

--- a/lib/sensors/include/sensors/wheelOdometry.hpp
+++ b/lib/sensors/include/sensors/wheelOdometry.hpp
@@ -1,5 +1,4 @@
 #include "ros/ros.h"
-#include "geometry_msgs/Twist.h"
 #include "webots/Motor.hpp"
 #include "webots/Supervisor.hpp"
 

--- a/lib/sensors/include/sensors/wheelOdometry.hpp
+++ b/lib/sensors/include/sensors/wheelOdometry.hpp
@@ -2,7 +2,6 @@
 #include "webots/Motor.hpp"
 #include "webots/Supervisor.hpp"
 
-
 namespace AutomatED {
 
 class WheelOdometry {
@@ -29,6 +28,12 @@ private:
 
   // ROS publisher
   ros::Publisher wheel_odometry_pub;
+
+  // Helper functions
+  void getLocalRotationalVelocity(webots::Node *solid, double *rvel_local);
+  void transposeOrientation(const double *matrix, double *matrix_t);
+  void transformVelocity(const double *matrix, const double *vector,
+                         double *new_vec);
 };
 
-}
+} // namespace AutomatED

--- a/lib/sensors/src/wheelOdometry.cpp
+++ b/lib/sensors/src/wheelOdometry.cpp
@@ -1,0 +1,76 @@
+#include "ros/ros.h"
+#include "sensors/wheelOdometry.hpp"
+#include "webots/Supervisor.hpp"
+#include "geometry_msgs/TwistStamped.h"
+
+
+using namespace AutomatED;
+
+WheelOdometry::WheelOdometry(webots::Supervisor *webots_supervisor,
+                             ros::NodeHandle *ros_handle) {
+
+  wb = webots_supervisor;
+  nh = ros_handle;
+
+  // Get ROS parameters
+  nh->param("wheel_odometry/sampling_period", sampling_period, 32);
+  nh->param<std::string>("wheel_odometry/twist_topic", wheel_odometry_twist_topic, 
+                         "wheel_odometry_twist");
+  nh->param("wheel_odometry/wheel_separation", wheel_separation, 0.6);
+  nh->param("wheel_odometry/wheel_radius", wheel_radius, 0.12);
+
+
+  // Create publishers
+  wheel_odometry_pub = 
+      nh->advertise<geometry_msgs::TwistStamped>(wheel_odometry_twist_topic, 1);
+
+
+
+  // TODO create an array of wheel names in odom file and iterate over that
+  // Get wheels
+  wheels[0] = wb->getMotor("front_left_wheel");
+  wheels[1] = wb->getMotor("front_right_wheel");
+  wheels[2] = wb->getMotor("rear_left_wheel");
+  wheels[3] = wb->getMotor("rear_right_wheel");
+
+}
+
+
+WheelOdometry::~WheelOdometry() {
+  wheel_odometry_pub.shutdown();
+}
+
+
+void WheelOdometry::publishWheelOdometry() {
+  webots::Node *front_left_node = wb->getFromDevice(wheels[0]);
+  webots::Node *front_right_node = wb->getFromDevice(wheels[0]);
+  webots::Node *rear_left_node = wb->getFromDevice(wheels[0]);
+  webots::Node *rear_right_node = wb->getFromDevice(wheels[0]);
+
+  // Get Linear and Angular velocities
+  const double *vel0 = front_left_node->getVelocity();
+  const double *vel1 = front_right_node->getVelocity();
+  const double *vel2 = rear_left_node->getVelocity();
+  const double *vel3 = rear_right_node->getVelocity();
+
+  const double avg_vel_left  = (vel0[0] + vel2[0]) / 2;
+  const double avg_vel_right = (vel1[0] + vel3[0]) / 2;
+
+  const double linear_vel_robot = 
+      wheel_radius * avg_vel_left  + (wheel_separation * avg_vel_right - wheel_separation * avg_vel_left);
+  const double angular_vel_robot = 
+      (wheel_radius * avg_vel_right - wheel_radius * avg_vel_left) / wheel_separation;
+
+  geometry_msgs::TwistStamped msg; 
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "wheel_odometry";
+  msg.twist.linear.x = linear_vel_robot;
+  msg.twist.linear.y = 0;
+  msg.twist.linear.z = 0;
+  msg.twist.angular.x = 0;
+  msg.twist.angular.y = 0;
+  msg.twist.angular.z = angular_vel_robot;
+
+  wheel_odometry_pub.publish(msg);
+
+}

--- a/lib/sensors/src/wheelOdometry.cpp
+++ b/lib/sensors/src/wheelOdometry.cpp
@@ -1,8 +1,7 @@
-#include "ros/ros.h"
 #include "sensors/wheelOdometry.hpp"
-#include "webots/Supervisor.hpp"
 #include "geometry_msgs/TwistStamped.h"
-
+#include "ros/ros.h"
+#include "webots/Supervisor.hpp"
 
 using namespace AutomatED;
 
@@ -14,63 +13,88 @@ WheelOdometry::WheelOdometry(webots::Supervisor *webots_supervisor,
 
   // Get ROS parameters
   nh->param("wheel_odometry/sampling_period", sampling_period, 32);
-  nh->param<std::string>("wheel_odometry/twist_topic", wheel_odometry_twist_topic, 
-                         "wheel_odometry_twist");
-  nh->param("wheel_odometry/wheel_separation", wheel_separation, 0.6);
-  nh->param("wheel_odometry/wheel_radius", wheel_radius, 0.12);
-
+  nh->param<std::string>("wheel_odometry/odom_topic",
+                         wheel_odometry_twist_topic, "wheel_odom");
+  nh->param("wheel_separation", wheel_separation, 0.6);
+  nh->param("wheel_radius", wheel_radius, 0.12);
 
   // Create publishers
-  wheel_odometry_pub = 
+  wheel_odometry_pub =
       nh->advertise<geometry_msgs::TwistStamped>(wheel_odometry_twist_topic, 1);
-
-
-
-  // TODO create an array of wheel names in odom file and iterate over that
-  // Get wheels
-  wheels[0] = wb->getMotor("front_left_wheel");
-  wheels[1] = wb->getMotor("front_right_wheel");
-  wheels[2] = wb->getMotor("rear_left_wheel");
-  wheels[3] = wb->getMotor("rear_right_wheel");
-
 }
 
-
-WheelOdometry::~WheelOdometry() {
-  wheel_odometry_pub.shutdown();
-}
-
+WheelOdometry::~WheelOdometry() { wheel_odometry_pub.shutdown(); }
 
 void WheelOdometry::publishWheelOdometry() {
-  webots::Node *front_left_node = wb->getFromDevice(wheels[0]);
-  webots::Node *front_right_node = wb->getFromDevice(wheels[0]);
-  webots::Node *rear_left_node = wb->getFromDevice(wheels[0]);
-  webots::Node *rear_right_node = wb->getFromDevice(wheels[0]);
+  // Get wheels from webots
+  webots::Node *fl_joint = wb->getFromDef("FRONT_LEFT_SOLID");
+  webots::Node *fr_joint = wb->getFromDef("FRONT_RIGHT_SOLID");
+  webots::Node *rl_joint = wb->getFromDef("REAR_LEFT_SOLID");
+  webots::Node *rr_joint = wb->getFromDef("REAR_RIGHT_SOLID");
 
-  // Get Linear and Angular velocities
-  const double *vel0 = front_left_node->getVelocity();
-  const double *vel1 = front_right_node->getVelocity();
-  const double *vel2 = rear_left_node->getVelocity();
-  const double *vel3 = rear_right_node->getVelocity();
+  // Get rotation velocity in wheel coordinate frame
+  double fl_rvel[3];
+  WheelOdometry::getLocalRotationalVelocity(fl_joint, fl_rvel);
+  double fr_rvel[3];
+  WheelOdometry::getLocalRotationalVelocity(fr_joint, fr_rvel);
+  double rl_rvel[3];
+  WheelOdometry::getLocalRotationalVelocity(rl_joint, rl_rvel);
+  double rr_rvel[3];
+  WheelOdometry::getLocalRotationalVelocity(rr_joint, rr_rvel);
 
-  const double avg_vel_left  = (vel0[0] + vel2[0]) / 2;
-  const double avg_vel_right = (vel1[0] + vel3[0]) / 2;
+  // Take average of both sides
+  const double lvel_avg = (fl_rvel[2] + rl_rvel[2]) / 2;
+  const double rvel_avg = (fr_rvel[2] + rr_rvel[2]) / 2;
 
-  const double linear_vel_robot = 
-      wheel_radius * avg_vel_left  + (wheel_separation * avg_vel_right - wheel_separation * avg_vel_left);
-  const double angular_vel_robot = 
-      (wheel_radius * avg_vel_right - wheel_radius * avg_vel_left) / wheel_separation;
+  // Calculate linear and rotational velocity of robot
+  const double robot_vel =
+      (lvel_avg * wheel_radius + rvel_avg * wheel_radius) / 2;
+  const double robot_rvel =
+      (rvel_avg * wheel_radius - lvel_avg * wheel_radius) / wheel_separation;
 
-  geometry_msgs::TwistStamped msg; 
+  geometry_msgs::TwistStamped msg;
   msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "wheel_odometry";
-  msg.twist.linear.x = linear_vel_robot;
+  msg.header.frame_id = "base_link";
+  msg.twist.linear.x = robot_vel;
   msg.twist.linear.y = 0;
   msg.twist.linear.z = 0;
   msg.twist.angular.x = 0;
   msg.twist.angular.y = 0;
-  msg.twist.angular.z = angular_vel_robot;
+  msg.twist.angular.z = robot_rvel;
 
+  // Publish message
   wheel_odometry_pub.publish(msg);
+}
 
+void WheelOdometry::getLocalRotationalVelocity(webots::Node *solid,
+                                               double *rvel_local) {
+  const double *vel = solid->getVelocity();
+  const double *orientation = solid->getOrientation();
+
+  double orientation_t[9];
+  WheelOdometry::transposeOrientation(orientation, orientation_t);
+  WheelOdometry::transformVelocity(orientation_t, vel, rvel_local);
+}
+
+void WheelOdometry::transposeOrientation(const double *matrix,
+                                         double *matrix_t) {
+  matrix_t[0] = matrix[0];
+  matrix_t[1] = matrix[3];
+  matrix_t[2] = matrix[6];
+  matrix_t[3] = matrix[1];
+  matrix_t[4] = matrix[4];
+  matrix_t[5] = matrix[7];
+  matrix_t[6] = matrix[2];
+  matrix_t[7] = matrix[5];
+  matrix_t[8] = matrix[8];
+}
+
+void WheelOdometry::transformVelocity(const double *matrix,
+                                      const double *vector, double *new_vec) {
+  new_vec[0] = (matrix[0] * vector[3]) + (matrix[1] * vector[4]) +
+               (matrix[2] * vector[5]);
+  new_vec[1] = (matrix[3] * vector[3]) + (matrix[4] * vector[4]) +
+               (matrix[5] * vector[2]);
+  new_vec[2] = (matrix[6] * vector[3]) + (matrix[7] * vector[4]) +
+               (matrix[8] * vector[5]);
 }

--- a/lib/steering/include/steering/diffSteering.hpp
+++ b/lib/steering/include/steering/diffSteering.hpp
@@ -1,25 +1,26 @@
-#include "ros/ros.h"
 #include "geometry_msgs/Twist.h"
+#include "ros/ros.h"
 #include "webots/Motor.hpp"
 
 namespace AutomatED {
-    
+
 class DiffSteering {
 public:
-  DiffSteering(webots::Motor *motors[], ros::NodeHandle *ros_handle);
+  DiffSteering(std::vector<webots::Motor *> motors,
+               ros::NodeHandle *ros_handle);
   ~DiffSteering();
 
 private:
-  webots::Motor **wheels;
+  std::vector<webots::Motor *> wheels;
   ros::NodeHandle *nh;
   double wheel_separation;
   double wheel_radius;
   int wheel_count;
-  
+
   // Create Subscriber
   ros::Subscriber cmd_vel_sub;
 
-  void velocityCallback(const geometry_msgs::TwistConstPtr& cmd);
+  void velocityCallback(const geometry_msgs::TwistConstPtr &cmd);
   void stopMotors();
 };
 

--- a/lib/steering/src/diffSteering.cpp
+++ b/lib/steering/src/diffSteering.cpp
@@ -1,44 +1,45 @@
-#include "ros/ros.h"
 #include "steering/diffSteering.hpp"
 #include "geometry_msgs/Twist.h"
+#include "ros/ros.h"
 #include "webots/Motor.hpp"
 
 using namespace AutomatED;
 
-DiffSteering::DiffSteering(webots::Motor *motors[], ros::NodeHandle *ros_handle){
+DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
+                           ros::NodeHandle *ros_handle) {
   wheels = motors;
   nh = ros_handle;
-  wheel_count = std::sizeof(wheels) / std::sizeof(*wheels);
+  wheel_count = wheels.size();
 
   // Get ROS parameters
-  nh->param("diffSteering/wheel_separation", wheel_separation, 0.6);
-  nh->param("diffSteering/wheel_radius", wheel_radius, 0.12);
+  nh->param("wheel_separation", wheel_separation, 0.6);
+  nh->param("wheel_radius", wheel_radius, 0.12);
 
   // Create Subscriber
-  cmd_vel_sub = nh->subscribe("/cmd_vel", 1, &DiffSteering::velocityCallback, this);
+  cmd_vel_sub =
+      nh->subscribe("/cmd_vel", 1, &DiffSteering::velocityCallback, this);
 
   // Turn on motors
   for (int i = 0; i < wheel_count; i++) {
     wheels[i]->setPosition(INFINITY);
     wheels[i]->setVelocity(0.0);
-  } 
-
+  }
 }
 
-DiffSteering::~DiffSteering(){
+DiffSteering::~DiffSteering() {
   // Clean up
   cmd_vel_sub.shutdown();
   stopMotors();
 }
 
-void DiffSteering::velocityCallback(const geometry_msgs::TwistConstPtr& cmd){
+void DiffSteering::velocityCallback(const geometry_msgs::TwistConstPtr &cmd) {
   double linear_vel = cmd->linear.x;
   double angular_vel = cmd->angular.z;
-  
-  const double vel_left  = 
-          (linear_vel - angular_vel * wheel_separation / 2.0)/wheel_radius;
+
+  const double vel_left =
+      (linear_vel - angular_vel * wheel_separation / 2.0) / wheel_radius;
   const double vel_right =
-          (linear_vel + angular_vel * wheel_separation / 2.0)/wheel_radius;
+      (linear_vel + angular_vel * wheel_separation / 2.0) / wheel_radius;
 
   // Set velocity to left wheels
   wheels[0]->setVelocity(vel_left);

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -4,6 +4,7 @@
 #include "sensors/lidar.hpp"
 #include "webots/GPS.hpp"
 #include "webots/InertialUnit.hpp"
+#include "sensors/wheelOdometry.hpp"
 #include "webots/Lidar.hpp"
 #include "webots/Motor.hpp"
 #include "webots/Supervisor.hpp"
@@ -24,12 +25,15 @@ int main(int argc, char **argv) {
   AutomatED::Lidar lidar = AutomatED::Lidar(supervisor, &nh);
   AutomatED::GPS gps = AutomatED::GPS(supervisor, &nh);
   AutomatED::InertialUnit imu = AutomatED::InertialUnit(supervisor, &nh);
+  AutomatED::WheelOdometry wheel_odometry = AutomatED::WheelOdometry(supervisor, &nh);
+
 
   while (supervisor->step(step_size) != -1) {
     lidar.publishLaserScan();
     gps.publishGPSCoordinate();
     gps.publishGPSSpeed();
     imu.publishImuQuaternion();
+    wheel_odometry.publishWheelOdometry();
   }
 
   // Clean up

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -2,10 +2,10 @@
 #include "sensors/gps.hpp"
 #include "sensors/inertialUnit.hpp"
 #include "sensors/lidar.hpp"
+#include "sensors/wheelOdometry.hpp"
 #include "steering/diffSteering.hpp"
 #include "webots/GPS.hpp"
 #include "webots/InertialUnit.hpp"
-#include "sensors/wheelOdometry.hpp"
 #include "webots/Lidar.hpp"
 #include "webots/Motor.hpp"
 #include "webots/Supervisor.hpp"
@@ -23,34 +23,29 @@ int main(int argc, char **argv) {
   webots::Supervisor *supervisor = new webots::Supervisor();
 
   // Get webots motors
-  webots::Motor *motors[4] = {
-    robot->getMotor("front_left_wheel"),
-    robot->getMotor("front_right_wheel"),
-    robot->getMotor("rear_left_wheel"),
-    robot->getMotor("rear_right_wheel")
-  };
-  
+  std::vector<webots::Motor *> motors = {
+      supervisor->getMotor("front_left_wheel"),
+      supervisor->getMotor("front_right_wheel"),
+      supervisor->getMotor("rear_left_wheel"),
+      supervisor->getMotor("rear_right_wheel")};
 
   // Instantiate sensor wrappers
   AutomatED::Lidar lidar = AutomatED::Lidar(supervisor, &nh);
   AutomatED::GPS gps = AutomatED::GPS(supervisor, &nh);
   AutomatED::InertialUnit imu = AutomatED::InertialUnit(supervisor, &nh);
-  AutomatED::WheelOdometry wheel_odometry = AutomatED::WheelOdometry(supervisor, &nh);
-
+  AutomatED::WheelOdometry wheel_odometry =
+      AutomatED::WheelOdometry(supervisor, &nh);
 
   // Instantiate steering
   AutomatED::DiffSteering diffSteering = AutomatED::DiffSteering(motors, &nh);
-  
+
   while (supervisor->step(step_size) != -1) {
     lidar.publishLaserScan();
     gps.publishGPSCoordinate();
     gps.publishGPSSpeed();
     imu.publishImuQuaternion();
-<<<<<<< HEAD
     wheel_odometry.publishWheelOdometry();
-=======
     ros::spinOnce();
->>>>>>> main
   }
 
   // Clean up

--- a/worlds/world.wbt
+++ b/worlds/world.wbt
@@ -24,7 +24,6 @@ DEF ACKERMAN Robot {
       name "imu"
     }
     GPS {
-      name "gps"
     }
     RobotisLds01 {
       translation 0 0.16 0
@@ -198,7 +197,7 @@ DEF ACKERMAN Robot {
           name "rear_right_wheel"
         }
       ]
-      endPoint Solid {
+      endPoint DEF REAR_RIGHT_SOLID Solid {
         translation 0.23 0 -0.3
         rotation 0 0 -1 0.2688217764005264
         children [
@@ -251,7 +250,7 @@ DEF ACKERMAN Robot {
           name "rear_left_wheel"
         }
       ]
-      endPoint Solid {
+      endPoint DEF REAR_LEFT_SOLID Solid {
         translation 0.23 0 0.3
         rotation 0 0 -0.9999999999999999 0.24601636923970086
         children [
@@ -289,7 +288,7 @@ DEF ACKERMAN Robot {
           name "front_right_wheel"
         }
       ]
-      endPoint Solid {
+      endPoint DEF FRONT_RIGHT_SOLID Solid {
         translation -0.23 0 -0.3
         rotation 0 0 0.9999999999999999 0.0002008820959725147
         children [
@@ -311,7 +310,7 @@ DEF ACKERMAN Robot {
           name "front_left_wheel"
         }
       ]
-      endPoint Solid {
+      endPoint DEF FRONT_LEFT_SOLID Solid {
         translation -0.23 0 0.3
         rotation 0 0 1 0.38755663544370483
         children [


### PR DESCRIPTION
This MR adds wheel odometry to the set of sensors in the `sensor` library. It takes the wheels of the robot and retreives their rotational velocity to calculate the linear and angular velocity of the entire robot.

It also fixes `diffSteering` by using `std::vector` to store the list of motors rather than a pointer array.