### PR TITLE
Add CI

### DIFF
--- a/.catkin_lint
+++ b/.catkin_lint
@@ -1,0 +1,3 @@
+[catkin_lint]
+rosdistro=noetic
+output=text

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ssh-key: ${{ secrets.CI_SSH_PRIVATE }}
           path: src/
       - name: Install ROS packages
         run: sudo rosdep install --from-paths src --ignore-src -r -y --rosdistro noetic

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: Continuous Integration
+
+on: [pull_request]
+
+jobs:
+  catkin_lint:
+    name: Catkin lint
+    runs-on: ubuntu-20.04
+    container: ros:noetic
+    steps:
+      - name: Install catkin_lint (and dependencies)
+        run: sudo apt update && sudo apt install -yq git catkin-lint
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Run catkin_lint
+        run: . /opt/ros/noetic/setup.sh && catkin_lint --config ./.catkin_lint src
+
+  catkin_build:
+    name: Build workspace
+    runs-on: ubuntu-20.04
+    container: ros:noetic
+    env:
+      WEBOTS_HOME: /usr/local/webots
+      LD_LIBRARY_PATH: "${WEBOTS_HOME}/lib/controller:$PATH"
+    steps:
+      - name: Setup ROS
+        run: |
+          sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+          sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+          sudo apt update && sudo apt install -yq git python3-catkin-tools python3-pip
+          sudo pip3 install -q catkin_pkg osrf_pycommon pyyaml setuptools sphinxcontrib-programoutput
+      - name: Install webots
+        run: |
+          sudo apt update && sudo apt install -yq wget software-properties-common
+          wget -qO- https://cyberbotics.com/Cyberbotics.asc | sudo apt-key add -
+          sudo apt-add-repository 'deb https://cyberbotics.com/debian/ binary-amd64/'
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get -yq install keyboard-configuration
+          sudo apt-get -yq install webots
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.CI_SSH_PRIVATE }}
+          path: src/
+      - name: Install ROS packages
+        run: sudo rosdep install --from-paths src --ignore-src -r -y --rosdistro noetic
+      - name: Build workspace
+        run: |
+          . /opt/ros/noetic/setup.sh
+          catkin build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Install catkin_lint (and dependencies)
         run: sudo apt update && sudo apt install -yq git catkin-lint
+      - name: Update rosdep
+        run: rosdep update
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Run catkin_lint


### PR DESCRIPTION
This MR adds a CI pipeline with two different checks (based on the CI configuration for Autonomous):
1. `catkin_lint` to check the configuration of our `CMakeLists.txt` and `package.xml` files
2. Running `catkin build` to ensure all package within this repository can build