### PR TITLE
Handle KeyboardInterrupt exception

### DIFF
--- a/launch/webots_launcher.py
+++ b/launch/webots_launcher.py
@@ -37,4 +37,7 @@ if options.noGui == 'true':
     command.append('--no-sandbox')
     command.append('--minimize')
 
-subprocess.call(command)
+try:
+    subprocess.call(command)
+except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
This adds a simple `try` block to catch the `KeyboardInterrupt` exception that gets thrown when you `Ctrl + c`. As far as I can tell, this is not strictly necessary, but makes the terminal cleaner when you exit.