### PR TITLE
Update sensor noise models

### DIFF
--- a/lib/sensors/include/sensors/accelerometer.hpp
+++ b/lib/sensors/include/sensors/accelerometer.hpp
@@ -4,43 +4,50 @@
 #include "webots/Supervisor.hpp"
 #include <random>
 
-namespace AutomatED {
+namespace AutomatED
+{
 
-class Accelerometer {
-public:
-  Accelerometer(webots::Supervisor *webots_supervisor,
-                ros::NodeHandle *ros_handle);
-  ~Accelerometer();
+  class Accelerometer
+  {
+  public:
+    Accelerometer(webots::Supervisor *webots_supervisor,
+                  ros::NodeHandle *ros_handle);
+    ~Accelerometer();
 
-  void publishAccelerometer();
+    void publishAccelerometer();
 
-private:
-  // Handlers
-  webots::Supervisor *wb;
-  ros::NodeHandle *nh;
+  private:
+    // Handlers
+    webots::Supervisor *wb;
+    ros::NodeHandle *nh;
 
-  // Webots devices
-  webots::Accelerometer *accelerometer;
+    // Webots devices
+    webots::Accelerometer *accelerometer;
 
-  // ROS parameters
-  std::string accelerometer_name;
-  int sampling_period;
-  std::string ground_truth_topic;
-  std::string noise_topic;
-  double noise_error;
-  int noise_seed;
+    // ROS parameters
+    std::string accelerometer_name;
+    std::string frame_id;
+    int sampling_period;
+    std::string ground_truth_topic;
+    std::string noise_topic;
+    double noise_mean;
+    double noise_std;
+    double bias_mean;
+    double bias_std;
+    int noise_seed;
 
-  // ROS publisher
-  ros::Publisher ground_truth_pub;
-  ros::Publisher noise_pub;
+    // ROS publisher
+    ros::Publisher ground_truth_pub;
+    ros::Publisher noise_pub;
 
-  // Tf2
-  tf2_ros::StaticTransformBroadcaster static_broadcaster;
-  void publishTF();
+    // Tf2
+    tf2_ros::StaticTransformBroadcaster static_broadcaster;
+    void publishTF();
 
-  // Noise
-  std::mt19937 *gen;
-  double gaussianNoise(double value);
-};
+    // Noise
+    std::mt19937 *gen;
+    double gaussianNoise();
+    double bias;
+  };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/gps.hpp
+++ b/lib/sensors/include/sensors/gps.hpp
@@ -4,46 +4,48 @@
 #include "webots/Supervisor.hpp"
 #include <random>
 
-namespace AutomatED {
+namespace AutomatED
+{
 
-class GPS {
-public:
-  GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
-  ~GPS();
+  class GPS
+  {
+  public:
+    GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
+    ~GPS();
 
-  void publishGPSCoordinate();
-  void publishGPSSpeed();
+    void publishGPSCoordinate();
 
-private:
-  webots::Supervisor *wb;
-  ros::NodeHandle *nh;
+  private:
+    webots::Supervisor *wb;
+    ros::NodeHandle *nh;
 
-  // Webots Devices
-  webots::GPS *gps;
+    // Webots Devices
+    webots::GPS *gps;
 
-  // ROS parameters
-  std::string gps_name;
-  int sampling_period;
-  std::string gt_coordinate_topic;
-  std::string gt_speed_topic;
-  std::string coordinate_topic;
-  std::string speed_topic;
-  double noise_error;
-  int noise_seed;
+    // ROS parameters
+    std::string gps_name;
+    std::string frame_id;
+    int sampling_period;
+    std::string gt_coordinate_topic;
+    std::string coordinate_topic;
+    double noise_mean;
+    double noise_std;
+    double bias_mean;
+    double bias_std;
+    int noise_seed;
 
-  // ROS publishers
-  ros::Publisher gt_coordinate_pub;
-  ros::Publisher coordinate_pub;
-  ros::Publisher gt_speed_pub;
-  ros::Publisher speed_pub;
+    // ROS publishers
+    ros::Publisher gt_coordinate_pub;
+    ros::Publisher coordinate_pub;
 
-  // Tf2
-  tf2_ros::StaticTransformBroadcaster static_broadcaster;
-  void publishTF();
+    // Tf2
+    tf2_ros::StaticTransformBroadcaster static_broadcaster;
+    void publishTF();
 
-  // Noise
-  std::mt19937 *gen;
-  double gaussianNoise(double value);
-};
+    // Noise
+    std::mt19937 *gen;
+    double gaussianNoise();
+    double bias;
+  };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/gyro.hpp
+++ b/lib/sensors/include/sensors/gyro.hpp
@@ -4,42 +4,49 @@
 #include "webots/Supervisor.hpp"
 #include <random>
 
-namespace AutomatED {
+namespace AutomatED
+{
 
-class Gyro {
-public:
-  Gyro(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
-  ~Gyro();
+  class Gyro
+  {
+  public:
+    Gyro(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
+    ~Gyro();
 
-  void publishGyro();
+    void publishGyro();
 
-private:
-  // Handlers
-  webots::Supervisor *wb;
-  ros::NodeHandle *nh;
+  private:
+    // Handlers
+    webots::Supervisor *wb;
+    ros::NodeHandle *nh;
 
-  // Webots devices
-  webots::Gyro *gyro;
+    // Webots devices
+    webots::Gyro *gyro;
 
-  // ROS parameters
-  std::string gyro_name;
-  int sampling_period;
-  std::string ground_truth_topic;
-  std::string noise_topic;
-  double noise_error;
-  int noise_seed;
+    // ROS parameters
+    std::string gyro_name;
+    std::string frame_id;
+    int sampling_period;
+    std::string ground_truth_topic;
+    std::string noise_topic;
+    double noise_mean;
+    double noise_std;
+    double bias_mean;
+    double bias_std;
+    int noise_seed;
 
-  // ROS publisher
-  ros::Publisher ground_truth_pub;
-  ros::Publisher noise_pub;
+    // ROS publisher
+    ros::Publisher ground_truth_pub;
+    ros::Publisher noise_pub;
 
-  // Tf2
-  tf2_ros::StaticTransformBroadcaster static_broadcaster;
-  void publishTF();
+    // Tf2
+    tf2_ros::StaticTransformBroadcaster static_broadcaster;
+    void publishTF();
 
-  // Noise
-  std::mt19937 *gen;
-  double gaussianNoise(double value);
-};
+    // Noise
+    std::mt19937 *gen;
+    double gaussianNoise();
+    double bias;
+  };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/inertialUnit.hpp
+++ b/lib/sensors/include/sensors/inertialUnit.hpp
@@ -4,43 +4,50 @@
 #include "webots/Supervisor.hpp"
 #include <random>
 
-namespace AutomatED {
+namespace AutomatED
+{
 
-class InertialUnit {
-public:
-  InertialUnit(webots::Supervisor *webots_supervisor,
-               ros::NodeHandle *ros_handle);
-  ~InertialUnit();
+  class InertialUnit
+  {
+  public:
+    InertialUnit(webots::Supervisor *webots_supervisor,
+                 ros::NodeHandle *ros_handle);
+    ~InertialUnit();
 
-  void publishImuQuaternion();
+    void publishImuQuaternion();
 
-private:
-  // Handlers
-  webots::Supervisor *wb;
-  ros::NodeHandle *nh;
+  private:
+    // Handlers
+    webots::Supervisor *wb;
+    ros::NodeHandle *nh;
 
-  // Webots devices
-  webots::InertialUnit *imu;
+    // Webots devices
+    webots::InertialUnit *imu;
 
-  // ROS parameters
-  std::string imu_name;
-  int sampling_period;
-  std::string ground_truth_topic;
-  std::string noise_topic;
-  double noise_error;
-  int noise_seed;
+    // ROS parameters
+    std::string imu_name;
+    std::string frame_id;
+    int sampling_period;
+    std::string ground_truth_topic;
+    std::string noise_topic;
+    double noise_mean;
+    double noise_std;
+    double bias_mean;
+    double bias_std;
+    int noise_seed;
 
-  // ROS publisher
-  ros::Publisher ground_truth_pub;
-  ros::Publisher noise_pub;
+    // ROS publisher
+    ros::Publisher ground_truth_pub;
+    ros::Publisher noise_pub;
 
-  // Tf2
-  tf2_ros::StaticTransformBroadcaster static_broadcaster;
-  void publishTF();
+    // Tf2
+    tf2_ros::StaticTransformBroadcaster static_broadcaster;
+    void publishTF();
 
-  // Noise
-  std::mt19937 *gen;
-  double gaussianNoise(double value);
-};
+    // Noise
+    std::mt19937 *gen;
+    double gaussianNoise();
+    double bias;
+  };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/lidar.hpp
+++ b/lib/sensors/include/sensors/lidar.hpp
@@ -4,42 +4,45 @@
 #include "webots/Supervisor.hpp"
 #include <random>
 
-namespace AutomatED {
+namespace AutomatED
+{
 
-class Lidar {
-public:
-  Lidar(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
-  ~Lidar();
+  class Lidar
+  {
+  public:
+    Lidar(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
+    ~Lidar();
 
-  void publishLaserScan();
+    void publishLaserScan();
 
-private:
-  // Handlers
-  webots::Supervisor *wb;
-  ros::NodeHandle *nh;
+  private:
+    // Handlers
+    webots::Supervisor *wb;
+    ros::NodeHandle *nh;
 
-  // Webots devices
-  webots::Lidar *lidar;
+    // Webots devices
+    webots::Lidar *lidar;
 
-  // ROS parameters
-  int sampling_period;
-  std::string ground_truth_topic;
-  std::string noise_topic;
-  double noise_error;
-  int noise_seed;
-  std::string lidar_name;
+    // ROS parameters
+    std::string lidar_name;
+    int sampling_period;
+    std::string ground_truth_topic;
+    std::string noise_topic;
+    double noise_mean;
+    double noise_std;
+    int noise_seed;
 
-  // ROS publisher
-  ros::Publisher ground_truth_pub;
-  ros::Publisher noise_pub;
+    // ROS publisher
+    ros::Publisher ground_truth_pub;
+    ros::Publisher noise_pub;
 
-  // Tf2
-  tf2_ros::StaticTransformBroadcaster static_broadcaster;
-  void publishTF();
+    // Tf2
+    tf2_ros::StaticTransformBroadcaster static_broadcaster;
+    void publishTF();
 
-  // Noise
-  std::mt19937 *gen;
-  double gaussianNoise(double value);
-};
+    // Noise
+    std::mt19937 *gen;
+    double gaussianNoise(double value);
+  };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/lidar.hpp
+++ b/lib/sensors/include/sensors/lidar.hpp
@@ -25,6 +25,7 @@ namespace AutomatED
 
     // ROS parameters
     std::string lidar_name;
+    std::string frame_id;
     int sampling_period;
     std::string ground_truth_topic;
     std::string noise_topic;
@@ -42,7 +43,7 @@ namespace AutomatED
 
     // Noise
     std::mt19937 *gen;
-    double gaussianNoise(double value);
+    double gaussianNoise();
   };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/wheelOdometry.hpp
+++ b/lib/sensors/include/sensors/wheelOdometry.hpp
@@ -3,46 +3,53 @@
 #include "webots/Supervisor.hpp"
 #include <random>
 
-namespace AutomatED {
+namespace AutomatED
+{
 
-class WheelOdometry {
-public:
-  WheelOdometry(webots::Supervisor *webots_supervisor,
-                ros::NodeHandle *ros_handle);
-  ~WheelOdometry();
+  class WheelOdometry
+  {
+  public:
+    WheelOdometry(webots::Supervisor *webots_supervisor,
+                  ros::NodeHandle *ros_handle);
+    ~WheelOdometry();
 
-  void publishWheelOdometry();
+    void publishWheelOdometry();
 
-private:
-  // Handlers
-  webots::Supervisor *wb;
-  ros::NodeHandle *nh;
+  private:
+    // Handlers
+    webots::Supervisor *wb;
+    ros::NodeHandle *nh;
 
-  // Webots devices
-  webots::Motor *wheels[4];
+    // Webots devices
+    webots::Motor *wheels[4];
 
-  // ROS parameters
-  int sampling_period;
-  std::string ground_truth_topic;
-  std::string noise_topic;
-  double noise_error;
-  int noise_seed;
-  double wheel_separation;
-  double wheel_radius;
+    // ROS parameters
+    std::string frame_id;
+    int sampling_period;
+    std::string ground_truth_topic;
+    std::string noise_topic;
+    double wheel_separation;
+    double wheel_radius;
+    double noise_mean;
+    double noise_std;
+    double bias_mean;
+    double bias_std;
+    int noise_seed;
 
-  // ROS publisher
-  ros::Publisher ground_truth_pub;
-  ros::Publisher noise_pub;
+    // ROS publisher
+    ros::Publisher ground_truth_pub;
+    ros::Publisher noise_pub;
 
-  // Noise
-  std::mt19937 *gen;
-  double gaussianNoise(double value);
+    // Noise
+    std::mt19937 *gen;
+    double gaussianNoise();
+    double bias;
 
-  // Helper functions
-  void getLocalRotationalVelocity(webots::Node *solid, double *rvel_local);
-  void transposeOrientation(const double *matrix, double *matrix_t);
-  void transformVelocity(const double *matrix, const double *vector,
-                         double *new_vec);
-};
+    // Helper functions
+    void getLocalRotationalVelocity(webots::Node *solid, double *rvel_local);
+    void transposeOrientation(const double *matrix, double *matrix_t);
+    void transformVelocity(const double *matrix, const double *vector,
+                           double *new_vec);
+  };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/wheelOdometry.hpp
+++ b/lib/sensors/include/sensors/wheelOdometry.hpp
@@ -30,10 +30,14 @@ namespace AutomatED
     std::string noise_topic;
     double wheel_separation;
     double wheel_radius;
-    double noise_mean;
-    double noise_std;
-    double bias_mean;
-    double bias_std;
+    double linear_mean;
+    double linear_std;
+    double linear_bias_mean;
+    double linear_bias_std;
+    double angular_mean;
+    double angular_std;
+    double angular_bias_mean;
+    double angular_bias_std;
     int noise_seed;
 
     // ROS publisher
@@ -42,8 +46,10 @@ namespace AutomatED
 
     // Noise
     std::mt19937 *gen;
-    double gaussianNoise();
-    double bias;
+    double linearGaussianNoise();
+    double angularGaussianNoise();
+    double linear_bias;
+    double angular_bias;
 
     // Helper functions
     void getLocalRotationalVelocity(webots::Node *solid, double *rvel_local);

--- a/lib/sensors/src/accelerometer.cpp
+++ b/lib/sensors/src/accelerometer.cpp
@@ -15,14 +15,10 @@ Accelerometer::Accelerometer(webots::Supervisor *webots_supervisor,
   wb = webots_supervisor;
   nh = ros_handle;
 
-  // Setup accelerometer device
-  accelerometer = wb->getAccelerometer(accelerometer_name);
-  accelerometer->enable(sampling_period);
-
   // Get ROS parameters
   nh->param<std::string>("accelerometer/name", accelerometer_name,
                          "accelerometer");
-  nh->param<std::string>("accelerometer/frame_id", frame_id, accelerometer->getName());
+  nh->param<std::string>("accelerometer/frame_id", frame_id, "accelerometer");
   nh->param("accelerometer/sampling_period", sampling_period, 32);
   nh->param<std::string>("accelerometer/ground_truth_topic", ground_truth_topic,
                          "/accelerometer/ground_truth");
@@ -37,6 +33,10 @@ Accelerometer::Accelerometer(webots::Supervisor *webots_supervisor,
   // Create publishers
   ground_truth_pub = nh->advertise<sensor_msgs::Imu>(ground_truth_topic, 1);
   noise_pub = nh->advertise<sensor_msgs::Imu>(noise_topic, 1);
+
+  // Setup accelerometer device
+  accelerometer = wb->getAccelerometer(accelerometer_name);
+  accelerometer->enable(sampling_period);
 
   // Publish tf
   publishTF();

--- a/lib/sensors/src/gps.cpp
+++ b/lib/sensors/src/gps.cpp
@@ -11,29 +11,29 @@
 
 using namespace AutomatED;
 
-GPS::GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle) {
+GPS::GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle)
+{
   wb = webots_supervisor;
   nh = ros_handle;
 
   // Get ROS parameters
   nh->param<std::string>("gps/name", gps_name, "gps");
+  nh->param<std::string>("gps/frame_id", frame_id, "gps");
   nh->param("gps/sampling_period", sampling_period, 32);
   nh->param<std::string>("gps/gt_coordinate_topic", gt_coordinate_topic,
                          "/gps/ground_truth/coordinates");
   nh->param<std::string>("gps/coordinate_topic", coordinate_topic,
                          "/gps/coordinates");
-  nh->param<std::string>("gps/gt_speed_topic", gt_speed_topic,
-                         "/gps/ground_truth/speed");
-  nh->param<std::string>("gps/speed_topic", speed_topic, "/gps/speed");
-  nh->param("gps/noise_error", noise_error, 0.05);
+  nh->param("gps/noise_mean", noise_mean, 0.0);
+  nh->param("gps/noise_std", noise_std, 0.017);
+  nh->param("gps/bias_mean", bias_mean, 0.1);
+  nh->param("gps/bias_std", bias_std, 0.001);
   nh->param("gps/noise_seed", noise_seed, 17);
 
   // Create publishers
   gt_coordinate_pub =
       nh->advertise<sensor_msgs::NavSatFix>(gt_coordinate_topic, 1);
   coordinate_pub = nh->advertise<sensor_msgs::NavSatFix>(coordinate_topic, 1);
-  gt_speed_pub = nh->advertise<webots_ros::Float64Stamped>(gt_speed_topic, 1);
-  speed_pub = nh->advertise<webots_ros::Float64Stamped>(speed_topic, 1);
 
   // Setup GPS device
   gps = wb->getGPS(gps_name);
@@ -44,24 +44,28 @@ GPS::GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle) {
 
   // Initialize generator with seed
   gen = new std::mt19937{(long unsigned int)noise_seed};
+
+  // Sample bias
+  std::normal_distribution<double> d{bias_mean, bias_std};
+  bias = d(*gen);
 }
 
-GPS::~GPS() {
+GPS::~GPS()
+{
   gt_coordinate_pub.shutdown();
   coordinate_pub.shutdown();
-  gt_speed_pub.shutdown();
-  speed_pub.shutdown();
   gps->disable();
 }
 
-void GPS::publishGPSCoordinate() {
+void GPS::publishGPSCoordinate()
+{
   // Get Coordinate reading from GPS
   const double *reading = gps->getValues();
 
   // Publish ground truth
   sensor_msgs::NavSatFix gt;
   gt.header.stamp = ros::Time::now();
-  gt.header.frame_id = gps->getName();
+  gt.header.frame_id = frame_id;
   gt.latitude = reading[0];
   gt.longitude = reading[2];
   gt.altitude = reading[1];
@@ -72,34 +76,22 @@ void GPS::publishGPSCoordinate() {
   // Publish data with noise
   sensor_msgs::NavSatFix msg;
   msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = gps->getName();
-  msg.latitude = reading[0] + gaussianNoise(reading[0]);
-  msg.longitude = reading[2] + gaussianNoise(reading[2]);
-  msg.altitude = reading[1] + gaussianNoise(reading[1]);
+  msg.header.frame_id = frame_id;
+  msg.latitude = reading[0] + bias + gaussianNoise();
+  msg.longitude = reading[2] + bias + gaussianNoise();
+  msg.altitude = reading[1] + bias + gaussianNoise();
   msg.position_covariance_type =
-      sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
+      sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+  // Populate variance along the diagonal
+  msg.position_covariance[0] = std::pow(bias + noise_mean + noise_std, 2);
+  msg.position_covariance[4] = std::pow(bias + noise_mean + noise_std, 2);
+  msg.position_covariance[8] = std::pow(bias + noise_mean + noise_std, 2);
   msg.status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
   coordinate_pub.publish(msg);
 }
 
-void GPS::publishGPSSpeed() {
-  // Get speed data from GPS
-  const double reading = gps->getSpeed();
-
-  // Publish ground truth
-  webots_ros::Float64Stamped gt;
-  gt.header.stamp = ros::Time::now();
-  gt.data = reading;
-  gt_speed_pub.publish(gt);
-
-  // Publish data with noise
-  webots_ros::Float64Stamped msg;
-  msg.header.stamp = ros::Time::now();
-  msg.data = reading + gaussianNoise(reading);
-  speed_pub.publish(msg);
-}
-
-void GPS::publishTF() {
+void GPS::publishTF()
+{
   // Get gps node
   webots::Node *gps_node = wb->getFromDevice(gps);
 
@@ -115,7 +107,7 @@ void GPS::publishTF() {
   geometry_msgs::TransformStamped msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "odom";
-  msg.child_frame_id = gps->getName();
+  msg.child_frame_id = frame_id;
 
   // Translate from Webots to ROS coordinates
   msg.transform.translation.x = gps_translation[0];
@@ -140,7 +132,8 @@ void GPS::publishTF() {
   static_broadcaster.sendTransform(msg);
 }
 
-double GPS::gaussianNoise(double value) {
-  std::normal_distribution<double> d{0, noise_error * value};
+double GPS::gaussianNoise()
+{
+  std::normal_distribution<double> d{noise_mean, noise_std};
   return d(*gen);
 }

--- a/lib/sensors/src/gps.cpp
+++ b/lib/sensors/src/gps.cpp
@@ -25,7 +25,7 @@ GPS::GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle)
   nh->param<std::string>("gps/coordinate_topic", coordinate_topic,
                          "/gps/coordinates");
   nh->param("gps/noise_mean", noise_mean, 0.0);
-  nh->param("gps/noise_std", noise_std, 0.017);
+  nh->param("gps/noise_std", noise_std, 0.1);
   nh->param("gps/bias_mean", bias_mean, 0.1);
   nh->param("gps/bias_std", bias_std, 0.001);
   nh->param("gps/noise_seed", noise_seed, 17);
@@ -69,7 +69,7 @@ void GPS::publishGPSCoordinate()
   gt.latitude = reading[0];
   gt.longitude = reading[2];
   gt.altitude = reading[1];
-  gt.position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
+  gt.position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
   gt.status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
   gt_coordinate_pub.publish(gt);
 

--- a/lib/sensors/src/inertialUnit.cpp
+++ b/lib/sensors/src/inertialUnit.cpp
@@ -24,8 +24,8 @@ InertialUnit::InertialUnit(webots::Supervisor *webots_supervisor,
                          "/imu/ground_truth");
   nh->param<std::string>("imu/noise_topic", noise_topic, "/imu/data");
   nh->param("imu/noise_mean", noise_mean, 0.0);
-  nh->param("imu/noise_std", noise_std, 0.017);
-  nh->param("imu/bias_mean", bias_mean, 0.1);
+  nh->param("imu/noise_std", noise_std, 0.02);
+  nh->param("imu/bias_mean", bias_mean, 0.005);
   nh->param("imu/bias_std", bias_std, 0.001);
   nh->param<int>("imu/noise_seed", noise_seed, 17);
 

--- a/lib/sensors/src/inertialUnit.cpp
+++ b/lib/sensors/src/inertialUnit.cpp
@@ -11,17 +11,22 @@
 using namespace AutomatED;
 
 InertialUnit::InertialUnit(webots::Supervisor *webots_supervisor,
-                           ros::NodeHandle *ros_handle) {
+                           ros::NodeHandle *ros_handle)
+{
   wb = webots_supervisor;
   nh = ros_handle;
 
   // Get ROS parameters
   nh->param<std::string>("imu/name", imu_name, "imu");
+  nh->param<std::string>("imu/frame_id", frame_id, "imu");
   nh->param("imu/sampling_period", sampling_period, 32);
   nh->param<std::string>("imu/ground_truth_topic", ground_truth_topic,
                          "/imu/ground_truth");
   nh->param<std::string>("imu/noise_topic", noise_topic, "/imu/data");
-  nh->param("imu/noise_error", noise_error, 0.05);
+  nh->param("imu/noise_mean", noise_mean, 0.0);
+  nh->param("imu/noise_std", noise_std, 0.017);
+  nh->param("imu/bias_mean", bias_mean, 0.1);
+  nh->param("imu/bias_std", bias_std, 0.001);
   nh->param<int>("imu/noise_seed", noise_seed, 17);
 
   // Create publishers
@@ -37,15 +42,21 @@ InertialUnit::InertialUnit(webots::Supervisor *webots_supervisor,
 
   // Initialize generator with seed
   gen = new std::mt19937{(long unsigned int)noise_seed};
+
+  // Sample bias
+  std::normal_distribution<double> d{bias_mean, bias_std};
+  bias = d(*gen);
 }
 
-InertialUnit::~InertialUnit() {
+InertialUnit::~InertialUnit()
+{
   ground_truth_pub.shutdown();
   noise_pub.shutdown();
   imu->disable();
 }
 
-void InertialUnit::publishImuQuaternion() {
+void InertialUnit::publishImuQuaternion()
+{
   // Get sensor reading
   const double *reading = imu->getQuaternion();
 
@@ -57,7 +68,7 @@ void InertialUnit::publishImuQuaternion() {
   // Publish ground truth
   sensor_msgs::Imu gt;
   gt.header.stamp = ros::Time::now();
-  gt.header.frame_id = imu->getName();
+  gt.header.frame_id = frame_id;
   gt.orientation.x = orientation.getX();
   gt.orientation.y = orientation.getY();
   gt.orientation.z = orientation.getZ();
@@ -69,17 +80,23 @@ void InertialUnit::publishImuQuaternion() {
   // Publish noisy data
   sensor_msgs::Imu msg;
   msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = imu->getName();
-  msg.orientation.x = orientation.getX() + gaussianNoise(orientation.getX());
-  msg.orientation.y = orientation.getY() + gaussianNoise(orientation.getY());
-  msg.orientation.z = orientation.getZ() + gaussianNoise(orientation.getZ());
-  msg.orientation.w = orientation.getW() + gaussianNoise(orientation.getW());
+  msg.header.frame_id = frame_id;
   msg.angular_velocity_covariance[0] = -1;      // no information
   msg.linear_acceleration_covariance[0] = -1.0; // no information
+  msg.orientation.x = orientation.getX() + bias + gaussianNoise();
+  msg.orientation.y = orientation.getY() + bias + gaussianNoise();
+  msg.orientation.z = orientation.getZ() + bias + gaussianNoise();
+  msg.orientation.w = orientation.getW() + bias + gaussianNoise();
+  // Populate variance along the diagonal
+  msg.orientation_covariance[0] = std::pow(bias + noise_mean + noise_std, 2);
+  msg.orientation_covariance[4] = std::pow(bias + noise_mean + noise_std, 2);
+  msg.orientation_covariance[8] = std::pow(bias + noise_mean + noise_std, 2);
+
   noise_pub.publish(msg);
 }
 
-void InertialUnit::publishTF() {
+void InertialUnit::publishTF()
+{
   // Get imu node
   webots::Node *imu_node = wb->getFromDevice(imu);
 
@@ -95,7 +112,7 @@ void InertialUnit::publishTF() {
   geometry_msgs::TransformStamped msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "base_link";
-  msg.child_frame_id = imu->getName();
+  msg.child_frame_id = frame_id;
 
   // Translate from Webots to ROS coordinates
   msg.transform.translation.x = imu_translation[0];
@@ -120,7 +137,8 @@ void InertialUnit::publishTF() {
   static_broadcaster.sendTransform(msg);
 }
 
-double InertialUnit::gaussianNoise(double value) {
-  std::normal_distribution<double> d{0, noise_error * value};
+double InertialUnit::gaussianNoise()
+{
+  std::normal_distribution<double> d{noise_mean, noise_std};
   return d(*gen);
 }

--- a/lib/sensors/src/wheelOdometry.cpp
+++ b/lib/sensors/src/wheelOdometry.cpp
@@ -14,7 +14,7 @@ WheelOdometry::WheelOdometry(webots::Supervisor *webots_supervisor,
   nh = ros_handle;
 
   // Get ROS parameters
-  nh->param<std::string>("wheel_odom/fram_id", frame_id, "base_link");
+  nh->param<std::string>("wheel_odom/frame_id", frame_id, "base_link");
   nh->param("wheel_odom/sampling_period", sampling_period, 32);
   nh->param<std::string>("wheel_odom/ground_truth_topic", ground_truth_topic,
                          "/wheel_odom/ground_truth");

--- a/lib/sensors/src/wheelOdometry.cpp
+++ b/lib/sensors/src/wheelOdometry.cpp
@@ -1,5 +1,5 @@
 #include "sensors/wheelOdometry.hpp"
-#include "geometry_msgs/TwistStamped.h"
+#include "geometry_msgs/TwistWithCovarianceStamped.h"
 #include "ros/ros.h"
 #include "webots/Supervisor.hpp"
 #include <random>
@@ -7,37 +7,48 @@
 using namespace AutomatED;
 
 WheelOdometry::WheelOdometry(webots::Supervisor *webots_supervisor,
-                             ros::NodeHandle *ros_handle) {
+                             ros::NodeHandle *ros_handle)
+{
 
   wb = webots_supervisor;
   nh = ros_handle;
 
   // Get ROS parameters
+  nh->param<std::string>("wheel_odom/fram_id", frame_id, "base_link");
   nh->param("wheel_odom/sampling_period", sampling_period, 32);
   nh->param<std::string>("wheel_odom/ground_truth_topic", ground_truth_topic,
                          "/wheel_odom/ground_truth");
   nh->param<std::string>("wheel_odom/noise_topic", noise_topic,
                          "/wheel_odom/data");
-  nh->param("wheel_odom/noise_error", noise_error, 0.05);
-  nh->param<int>("wheel_odom/noise_seed", noise_seed, 17);
   nh->param("wheel_separation", wheel_separation, 0.6);
   nh->param("wheel_radius", wheel_radius, 0.12);
+  nh->param("wheel_odom/noise_mean", noise_mean, 0.0);
+  nh->param("wheel_odom/noise_std", noise_std, 0.017);
+  nh->param("wheel_odom/bias_mean", bias_mean, 0.1);
+  nh->param("wheel_odom/bias_std", bias_std, 0.001);
+  nh->param<int>("wheel_odom/noise_seed", noise_seed, 17);
 
   // Create publishers
   ground_truth_pub =
-      nh->advertise<geometry_msgs::TwistStamped>(ground_truth_topic, 1);
-  noise_pub = nh->advertise<geometry_msgs::TwistStamped>(noise_topic, 1);
+      nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(ground_truth_topic, 1);
+  noise_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(noise_topic, 1);
 
   // Initialize generator with seed
   gen = new std::mt19937{(long unsigned int)noise_seed};
+
+  // Sample bias
+  std::normal_distribution<double> d{bias_mean, bias_std};
+  bias = d(*gen);
 }
 
-WheelOdometry::~WheelOdometry() {
+WheelOdometry::~WheelOdometry()
+{
   ground_truth_pub.shutdown();
   noise_pub.shutdown();
 }
 
-void WheelOdometry::publishWheelOdometry() {
+void WheelOdometry::publishWheelOdometry()
+{
   // Get wheels from webots
   webots::Node *fl_joint = wb->getFromDef("FRONT_LEFT_SOLID");
   webots::Node *fr_joint = wb->getFromDef("FRONT_RIGHT_SOLID");
@@ -65,24 +76,27 @@ void WheelOdometry::publishWheelOdometry() {
       (rvel_avg * wheel_radius - lvel_avg * wheel_radius) / wheel_separation;
 
   // Publish ground truth
-  geometry_msgs::TwistStamped gt;
+  geometry_msgs::TwistWithCovarianceStamped gt;
   gt.header.stamp = ros::Time::now();
-  gt.header.frame_id = "base_link";
-  gt.twist.linear.x = robot_vel;
-  gt.twist.angular.z = robot_rvel;
+  gt.header.frame_id = frame_id;
+  gt.twist.twist.linear.x = robot_vel;
+  gt.twist.twist.angular.z = robot_rvel;
   ground_truth_pub.publish(gt);
 
   // Publish noisy data
-  geometry_msgs::TwistStamped msg;
+  geometry_msgs::TwistWithCovarianceStamped msg;
   msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "base_link";
-  msg.twist.linear.x = robot_vel + gaussianNoise(robot_vel);
-  msg.twist.angular.z = robot_rvel + gaussianNoise(robot_rvel);
+  msg.header.frame_id = frame_id;
+  msg.twist.twist.linear.x = robot_vel + bias + gaussianNoise();
+  msg.twist.twist.angular.z = robot_rvel + bias + gaussianNoise();
+  msg.twist.covariance[0] = std::pow(bias + noise_mean + noise_std, 2);
+  msg.twist.covariance[35] = std::pow(bias + noise_mean + noise_std, 2);
   noise_pub.publish(msg);
 }
 
 void WheelOdometry::getLocalRotationalVelocity(webots::Node *solid,
-                                               double *rvel_local) {
+                                               double *rvel_local)
+{
   const double *vel = solid->getVelocity();
   const double *orientation = solid->getOrientation();
 
@@ -92,7 +106,8 @@ void WheelOdometry::getLocalRotationalVelocity(webots::Node *solid,
 }
 
 void WheelOdometry::transposeOrientation(const double *matrix,
-                                         double *matrix_t) {
+                                         double *matrix_t)
+{
   matrix_t[0] = matrix[0];
   matrix_t[1] = matrix[3];
   matrix_t[2] = matrix[6];
@@ -105,7 +120,8 @@ void WheelOdometry::transposeOrientation(const double *matrix,
 }
 
 void WheelOdometry::transformVelocity(const double *matrix,
-                                      const double *vector, double *new_vec) {
+                                      const double *vector, double *new_vec)
+{
   new_vec[0] = (matrix[0] * vector[3]) + (matrix[1] * vector[4]) +
                (matrix[2] * vector[5]);
   new_vec[1] = (matrix[3] * vector[3]) + (matrix[4] * vector[4]) +
@@ -114,7 +130,8 @@ void WheelOdometry::transformVelocity(const double *matrix,
                (matrix[8] * vector[5]);
 }
 
-double WheelOdometry::gaussianNoise(double value) {
-  std::normal_distribution<double> d{0, noise_error * value};
+double WheelOdometry::gaussianNoise()
+{
+  std::normal_distribution<double> d{noise_mean, noise_std};
   return d(*gen);
 }

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -10,7 +10,8 @@
 #include "webots/Motor.hpp"
 #include "webots/Supervisor.hpp"
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   // Set up ROS node
   ros::init(argc, argv, "full_controller");
   ros::NodeHandle nh("~");
@@ -48,16 +49,17 @@ int main(int argc, char **argv) {
   AutomatED::KeyboardController keyboard =
       AutomatED::KeyboardController(supervisor, &nh);
 
-  while (supervisor->step(step_size) != -1) {
+  while (supervisor->step(step_size) != -1)
+  {
     lidar.publishLaserScan();
     gps.publishGPSCoordinate();
-    gps.publishGPSSpeed();
     imu.publishImuQuaternion();
     gyro.publishGyro();
     accelerometer.publishAccelerometer();
     wheel_odometry.publishWheelOdometry();
 
-    if (use_keyboard_control) {
+    if (use_keyboard_control)
+    {
       keyboard.keyLoop();
     }
 


### PR DESCRIPTION
This PR does two main things:
1. It parametrizes the value of the `frame_id` field of the message that each sensor publishes rather than taking the `frame_id` to be the name of the device in simulation. This way it is easier for us to change the value as we can override the default parameter rather than going into the simulation and changing the name of the device.
2. Use a fixed Gaussian distribution to model sensor noise. Separate distributions were used for linear vs angular if applicable. We also introduce the concept of `bias` which represents a constant offset of the sensor reading from the ground truth. This was heavily inspired by the [Gazebo Sensor Noise Model](http://gazebosim.org/tutorials?tut=sensor_noise&cat=sensors). This tutorial provided default values for all sensors except the `inertialUnit`, `gps` and `wheelOdometry`. It would be nice at some point to find some values that we can use, but for now I've set them to some values.

As part of this change we also remove the GPS speed data as we are unlikely to use that in real-life due to its inaccuracy and latency.