### PR TITLE
Fix sensors

### DIFF
--- a/lib/sensors/src/accelerometer.cpp
+++ b/lib/sensors/src/accelerometer.cpp
@@ -143,7 +143,7 @@ void Accelerometer::publishTF()
                    accelerometer_rotation[2]}, accelerometer_rotation[3]);
 
   tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5707, 0, 0);
+  ros_to_webots.setRPY(1.5708, 0, 0);
 
   tf2::Quaternion quat = ros_to_webots * rot;
   quat.normalize();

--- a/lib/sensors/src/accelerometer.cpp
+++ b/lib/sensors/src/accelerometer.cpp
@@ -132,7 +132,7 @@ void Accelerometer::publishTF()
   msg.header.frame_id = "base_link";
   msg.child_frame_id = frame_id;
 
-  // Translate from Webots to ROS coordinates
+  // Translate from ROS to Webots coordinates
   msg.transform.translation.x = accelerometer_translation[0];
   msg.transform.translation.y = -1 * accelerometer_translation[2];
   msg.transform.translation.z = accelerometer_translation[1];

--- a/lib/sensors/src/gyro.cpp
+++ b/lib/sensors/src/gyro.cpp
@@ -131,7 +131,7 @@ void Gyro::publishTF()
                    gyro_rotation[2]}, gyro_rotation[3]);
 
   tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5707, 0, 0);
+  ros_to_webots.setRPY(1.5708, 0, 0);
 
   tf2::Quaternion quat = ros_to_webots * rot;
   quat.normalize();

--- a/lib/sensors/src/inertialUnit.cpp
+++ b/lib/sensors/src/inertialUnit.cpp
@@ -131,7 +131,7 @@ void InertialUnit::publishTF()
                    imu_rotation[2]}, imu_rotation[3]);
 
   tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5707, 0, 0);
+  ros_to_webots.setRPY(1.5708, 0, 0);
 
   tf2::Quaternion quat = ros_to_webots * rot;
   quat.normalize();

--- a/lib/sensors/src/inertialUnit.cpp
+++ b/lib/sensors/src/inertialUnit.cpp
@@ -99,9 +99,20 @@ void InertialUnit::publishTF()
   webots::Field *imu_translation_field = imu_node->getField("translation");
   const double *imu_translation = imu_translation_field->getSFVec3f();
 
+  ROS_DEBUG("IMU translation: [%f, %f, %f]",
+            imu_translation[0],
+            imu_translation[1],
+            imu_translation[2]);
+
   // Get imu rotation
   webots::Field *imu_rotation_field = imu_node->getField("rotation");
   const double *imu_rotation = imu_rotation_field->getSFRotation();
+
+  ROS_DEBUG("IMU rotation: [%f, %f, %f, %f]",
+            imu_rotation[0],
+            imu_rotation[1],
+            imu_rotation[2],
+            imu_rotation[3]);
 
   // Create transform msg
   geometry_msgs::TransformStamped msg;

--- a/lib/sensors/src/lidar.cpp
+++ b/lib/sensors/src/lidar.cpp
@@ -155,7 +155,7 @@ void Lidar::publishTF()
                    lidar_rotation[2]}, lidar_rotation[3]);
 
   tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5707, 0, 0);
+  ros_to_webots.setRPY(1.5708, 0, 0);
 
   tf2::Quaternion quat = ros_to_webots * rot;
   msg.transform.rotation.x = quat.x();

--- a/lib/sensors/src/lidar.cpp
+++ b/lib/sensors/src/lidar.cpp
@@ -54,7 +54,7 @@ Lidar::~Lidar()
 
 void Lidar::publishLaserScan()
 {
-  for (int layer = 0; layer < lidar->getNumberOfLayers(); ++layer)
+  for (int layer = 0; layer < lidar->getNumberOfLayers(); layer++)
   {
     const float *rangeImageVector = lidar->getLayerRangeImage(layer);
 
@@ -73,7 +73,7 @@ void Lidar::publishLaserScan()
 
     gt.range_min = lidar->getMinRange();
     gt.range_max = lidar->getMaxRange();
-    for (int i = 0; i < lidar->getHorizontalResolution(); ++i)
+    for (int i = 0; i < lidar->getHorizontalResolution(); i++)
     {
       gt.ranges.push_back(rangeImageVector[i]);
     }
@@ -95,7 +95,7 @@ void Lidar::publishLaserScan()
 
     msg.range_min = lidar->getMinRange();
     msg.range_max = lidar->getMaxRange();
-    for (int i = 0; i < lidar->getHorizontalResolution(); ++i)
+    for (int i = 0; i < lidar->getHorizontalResolution(); i++)
     {
       if (rangeImageVector[i] == INFINITY)
       {
@@ -123,9 +123,20 @@ void Lidar::publishTF()
   webots::Field *lidar_translation_field = lidar_node->getField("translation");
   const double *lidar_translation = lidar_translation_field->getSFVec3f();
 
+  ROS_DEBUG("Lidar translation: [%f, %f, %f]",
+           lidar_translation[0],
+           lidar_translation[1],
+           lidar_translation[2]);
+
   // Get lidar rotation
   webots::Field *lidar_rotation_field = lidar_node->getField("rotation");
   const double *lidar_rotation = lidar_rotation_field->getSFRotation();
+
+  ROS_DEBUG("Lidar rotation: [%f, %f, %f, %f]",
+           lidar_rotation[0],
+           lidar_rotation[1],
+           lidar_rotation[2],
+           lidar_rotation[3]);
 
   // Create transform msg
   geometry_msgs::TransformStamped msg;
@@ -139,15 +150,14 @@ void Lidar::publishTF()
   msg.transform.translation.z = lidar_translation[1];
 
   tf2::Quaternion rot;
-  rot[0] = lidar_rotation[1];
-  rot[1] = lidar_rotation[2];
-  rot[2] = lidar_rotation[3];
-  rot[3] = lidar_rotation[0];
+  rot.setRotation({lidar_rotation[0],
+                   lidar_rotation[1],
+                   lidar_rotation[2]}, lidar_rotation[3]);
 
-  tf2::Quaternion webots_to_ros;
-  webots_to_ros.setRPY(-1.5707, 0, 0);
+  tf2::Quaternion ros_to_webots;
+  ros_to_webots.setRPY(1.5707, 0, 0);
 
-  tf2::Quaternion quat = webots_to_ros * rot;
+  tf2::Quaternion quat = ros_to_webots * rot;
   msg.transform.rotation.x = quat.x();
   msg.transform.rotation.y = quat.y();
   msg.transform.rotation.z = quat.z();

--- a/lib/steering/src/diffSteering.cpp
+++ b/lib/steering/src/diffSteering.cpp
@@ -62,9 +62,9 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
 DiffSteering::~DiffSteering()
 {
   // Clean up
-  cmd_vel_sub.shutdown();
   ground_truth_pub.shutdown();
   noise_pub.shutdown();
+  cmd_vel_sub.shutdown();
   stopMotors();
 }
 

--- a/protos/StreetSmart.proto
+++ b/protos/StreetSmart.proto
@@ -40,19 +40,6 @@ PROTO StreetSmart [
       ]
     }
     DEF FRONT_AXEL Transform {
-      translation -0.23 0 0
-      rotation 1 0 0 1.5708
-      children [
-        Shape {
-          appearance PBRAppearance {}
-          geometry Cylinder {
-            height 0.6
-            radius 0.01
-          }
-        }
-      ]
-    }
-    DEF REAR_AXEL Transform {
       translation 0.23 0 0
       rotation 1 0 0 1.5708
       children [
@@ -65,8 +52,21 @@ PROTO StreetSmart [
         }
       ]
     }
+    DEF REAR_AXEL Transform {
+      translation -0.23 0 0
+      rotation 1 0 0 1.5708
+      children [
+        Shape {
+          appearance PBRAppearance {}
+          geometry Cylinder {
+            height 0.6
+            radius 0.01
+          }
+        }
+      ]
+    }
     LED {
-      translation -0.33 0 -0.18
+      translation 0.33 0 0.18
       children [
         Group {
           children [
@@ -84,7 +84,7 @@ PROTO StreetSmart [
               attenuation 0 0 1
               beamWidth 0.7
               color 0 0 0
-              direction -1 0 0
+              direction 1 0 0
               on FALSE
             }
           ]
@@ -96,7 +96,7 @@ PROTO StreetSmart [
       ]
     }
     LED {
-      translation -0.33 0 0.18
+      translation 0.33 0 -0.18
       children [
         Group {
           children [
@@ -114,7 +114,7 @@ PROTO StreetSmart [
               attenuation 0 0 1
               beamWidth 0.7
               color 0 0 0
-              direction -1 0 0
+              direction 1 0 0
               on FALSE
             }
           ]
@@ -126,7 +126,7 @@ PROTO StreetSmart [
       ]
     }
     LED {
-      translation 0.33 0 -0.18
+      translation -0.33 0 0.18
       children [
         Group {
           children [
@@ -153,7 +153,7 @@ PROTO StreetSmart [
       name "rear_right_led"
     }
     LED {
-      translation 0.33 0 0.18
+      translation -0.33 0 -0.18
       children [
         Group {
           children [
@@ -182,8 +182,8 @@ PROTO StreetSmart [
     DEF REAR_RIGHT_WHEEL HingeJoint {
       jointParameters HingeJointParameters {
         position 0
-        axis 0 0 1
-        anchor 0.23 0 -0.3
+        axis 0 0 -1
+        anchor -0.23 0 0.3
       }
       device [
         RotationalMotor {
@@ -191,7 +191,7 @@ PROTO StreetSmart [
         }
       ]
       endPoint DEF REAR_RIGHT_SOLID Solid {
-        translation 0.23 0 -0.3
+        translation -0.23 0 0.3
         rotation 0 0 -1 0
         children [
           DEF WHEEL_ROT Transform {
@@ -235,8 +235,8 @@ PROTO StreetSmart [
     DEF REAR_LEFT_WHEEL HingeJoint {
       jointParameters HingeJointParameters {
         position 0
-        axis 0 0 1
-        anchor 0.23 0 0.3
+        axis 0 0 -1
+        anchor -0.23 0 -0.3
       }
       device [
         RotationalMotor {
@@ -244,7 +244,7 @@ PROTO StreetSmart [
         }
       ]
       endPoint DEF REAR_LEFT_SOLID Solid {
-        translation 0.23 0 0.3
+        translation -0.23 0 -0.3
         rotation 0 0 -1 0
         children [
           USE WHEEL_ROT
@@ -258,8 +258,8 @@ PROTO StreetSmart [
     DEF FRONT_RIGHT_WHEEL HingeJoint {
       jointParameters HingeJointParameters {
         position 0
-        axis 0 0 1
-        anchor -0.23 0 -0.3
+        axis 0 0 -1
+        anchor 0.23 0 0.3
       }
       device [
         RotationalMotor {
@@ -267,7 +267,7 @@ PROTO StreetSmart [
         }
       ]
       endPoint DEF FRONT_RIGHT_SOLID Solid {
-        translation -0.23 0 -0.3
+        translation 0.23 0 0.3
         rotation 0 0 1 0
         children [
           USE WHEEL_ROT
@@ -281,8 +281,8 @@ PROTO StreetSmart [
     DEF FRONT_LEFT_WHEEL HingeJoint {
       jointParameters HingeJointParameters {
         position 0
-        axis 0 0 1
-        anchor -0.23 0 0.3
+        axis 0 0 -1
+        anchor 0.23 0 -0.3
       }
       device [
         RotationalMotor {
@@ -290,7 +290,7 @@ PROTO StreetSmart [
         }
       ]
       endPoint DEF FRONT_LEFT_SOLID Solid {
-        translation -0.23 0 0.3
+        translation 0.23 0 -0.3
         rotation 0 0 1 0
         children [
           USE WHEEL_ROT


### PR DESCRIPTION
This PR fixes some bugs that were introduced when implementing the sensor wrappers. The common bugs were:
1. The transform rotation was -1.5707 rather than 1.5707
2. The rotation values of the sensors were not correctly converted to quaternions
3. Transformations were applied to the IMU sensor data before publishing which was incorrect
4. Fix the orientation of the robot. Previously moving the robot forward would send it in the negative X direction rather than the positive X direction.

Hopefully these changes allow work on robot_localization, acml and move_base to progress.

If any bugs in the GPS sensor are found, fixes will be introduced on a separate PR.