### PR TITLE
Prevent instantiation of keyboard controller if param not set

### DIFF
--- a/lib/utils/src/KeyboardController.cpp
+++ b/lib/utils/src/KeyboardController.cpp
@@ -7,7 +7,7 @@ using namespace AutomatED;
 
 KeyboardController::KeyboardController(webots::Supervisor *webots_supervisor,
                                        ros::NodeHandle *ros_handle) {
-  ROS_INFO("Starting C++ Keyboard Controller...");
+  ROS_INFO("Starting C++ keyboard controller...");
 
   // ROS Node Handle
   nh_ = ros_handle;

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -45,9 +45,11 @@ int main(int argc, char **argv)
   AutomatED::DiffSteering diffSteering = AutomatED::DiffSteering(motors, &nh);
 
   // Instaniate keyboard steering
-  AutomatED::KeyboardController keyboard =
-      AutomatED::KeyboardController(supervisor, &nh);
-
+  AutomatED::KeyboardController *keyboard;
+  if (use_keyboard_control) {
+    keyboard = new AutomatED::KeyboardController(supervisor, &nh);
+  }
+  
   while (supervisor->step(step_size) != -1)
   {
     lidar.publishLaserScan();
@@ -59,7 +61,7 @@ int main(int argc, char **argv)
 
     if (use_keyboard_control)
     {
-      keyboard.keyLoop();
+      keyboard->keyLoop();
     }
 
     ros::spinOnce();


### PR DESCRIPTION
Previously, the `full_controller` will instantiate the webots C++ controller even if the `use_keyboard_controller` parameter is false. Although it doesn't get used, it still logs "Starting C++ Keyboard Controller...".

The changes in this PR only creates a object if the `use_keyboard_controller` parameter is set to true.