### PR TITLE
Add position sensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,14 @@ include_directories(
 )
 
 ## Declare a C++ library
-add_library(sensors lib/sensors/src/lidar.cpp lib/sensors/src/gps.cpp lib/sensors/src/inertialUnit.cpp lib/sensors/src/accelerometer.cpp lib/sensors/src/gyro.cpp)
+add_library(sensors
+    lib/sensors/src/lidar.cpp
+    lib/sensors/src/gps.cpp
+    lib/sensors/src/inertialUnit.cpp
+    lib/sensors/src/accelerometer.cpp
+    lib/sensors/src/gyro.cpp
+    lib/sensors/src/wheelOdom.cpp
+)
 add_library(steering lib/steering/src/diffSteering.cpp)
 add_library(utils lib/utils/src/KeyboardController.cpp)
 target_link_libraries(sensors ${WEBOTS_LIB} ${catkin_LIBRARIES})

--- a/lib/sensors/include/sensors/wheelOdom.hpp
+++ b/lib/sensors/include/sensors/wheelOdom.hpp
@@ -29,6 +29,8 @@ namespace AutomatED
         // Wheel position
         double prev_r_pos;
         double prev_l_pos;
+        double prev_noisy_r_pos;
+        double prev_noisy_l_pos;
         ros::Time prev_time;
 
         // ROS parameters
@@ -55,7 +57,7 @@ namespace AutomatED
         double gaussianNoise();
 
         // Helpers
-        double calcLinearVelocity(double r_pos, double l_pos, ros::Time curr_time);
+        double calcLinearVelocity(double dr, double dl, ros::Time curr_time);
     };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/wheelOdom.hpp
+++ b/lib/sensors/include/sensors/wheelOdom.hpp
@@ -1,0 +1,61 @@
+#include "ros/ros.h"
+#include "tf2_ros/static_transform_broadcaster.h"
+#include "webots/PositionSensor.hpp"
+#include "webots/Supervisor.hpp"
+#include <random>
+
+namespace AutomatED
+{
+
+    class WheelOdom
+    {
+    public:
+        WheelOdom(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle);
+        ~WheelOdom();
+
+        void publishWheelOdom();
+
+    private:
+        // Handlers
+        webots::Supervisor *wb;
+        ros::NodeHandle *nh;
+
+        // Webots devices
+        webots::PositionSensor *rr_odom;
+        webots::PositionSensor *rl_odom;
+        webots::PositionSensor *fr_odom;
+        webots::PositionSensor *fl_odom;
+
+        // Wheel position
+        double prev_r_pos;
+        double prev_l_pos;
+        ros::Time prev_time;
+
+        // ROS parameters
+        std::string rr_name;
+        std::string rl_name;
+        std::string fr_name;
+        std::string fl_name;
+        std::string frame_id;
+        int sampling_period;
+        std::string ground_truth_topic;
+        std::string noise_topic;
+        double noise_mean;
+        double noise_std;
+        int noise_seed;
+        double wheel_separation;
+        double wheel_radius;
+
+        // ROS publisher
+        ros::Publisher ground_truth_pub;
+        ros::Publisher noise_pub;
+
+        // Noise
+        std::mt19937 *gen;
+        double gaussianNoise();
+
+        // Helpers
+        double calcLinearVelocity(double r_pos, double l_pos, ros::Time curr_time);
+    };
+
+} // namespace AutomatED

--- a/lib/sensors/src/wheelOdom.cpp
+++ b/lib/sensors/src/wheelOdom.cpp
@@ -1,0 +1,137 @@
+#include "sensors/wheelOdom.hpp"
+#include "geometry_msgs/TwistWithCovarianceStamped.h"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_ros/static_transform_broadcaster.h"
+#include "webots/PositionSensor.hpp"
+#include "webots/Supervisor.hpp"
+#include <random>
+
+using namespace AutomatED;
+
+WheelOdom::WheelOdom(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle)
+{
+    wb = webots_supervisor;
+    nh = ros_handle;
+
+    // Get ROS parameters
+    nh->param<std::string>("wheel_odom/rear_right_name", rr_name, "rr_odom");
+    nh->param<std::string>("wheel_odom/rear_left_name", rl_name, "rl_odom");
+    nh->param<std::string>("wheel_odom/front_right_name", fr_name, "fr_odom");
+    nh->param<std::string>("wheel_odom/front_left_name", fl_name, "fl_odom");
+    nh->param<std::string>("wheel_odom/frame_id", frame_id, "base_link");
+    nh->param("wheel_odom/sampling_period", sampling_period, 32);
+    nh->param<std::string>("wheel_odom/ground_truth_topic", ground_truth_topic, "/wheel_odom/ground_truth");
+    nh->param<std::string>("wheel_odom/noise_topic", noise_topic, "/wheel_odom/data");
+    nh->param("wheel_odom/noise_mean", noise_mean, 0.0);
+    nh->param("wheel_odom/noise_std", noise_std, 0.002);
+    nh->param<int>("wheel_odom/noise_seed", noise_seed, 17);
+    nh->param("wheel_separation", wheel_separation, 0.6);
+    nh->param("wheel_radius", wheel_radius, 0.12);
+
+    // Create publishers
+    ground_truth_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(ground_truth_topic, 1);
+    noise_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(noise_topic, 1);
+
+    // Get wheel position sensors
+    rr_odom = wb->getPositionSensor(rr_name);
+    rl_odom = wb->getPositionSensor(rl_name);
+    fr_odom = wb->getPositionSensor(fr_name);
+    fl_odom = wb->getPositionSensor(fl_name);
+
+    // Enable wheel position sensors
+    rr_odom->enable(sampling_period);
+    rl_odom->enable(sampling_period);
+    fr_odom->enable(sampling_period);
+    fl_odom->enable(sampling_period);
+
+    // Initalize position values
+    prev_r_pos = 0;
+    prev_l_pos = 0;
+    prev_time = ros::Time::now();
+
+    // Initialize generator with seed
+    gen = new std::mt19937{(long unsigned int)noise_seed};
+}
+
+WheelOdom::~WheelOdom()
+{
+    noise_pub.shutdown();
+    ground_truth_pub.shutdown();
+
+    // Disable each position sensor
+    rr_odom->disable();
+    rl_odom->disable();
+    fr_odom->disable();
+    fl_odom->disable();
+}
+
+void WheelOdom::publishWheelOdom()
+{
+    // Get time
+    ros::Time curr_time = ros::Time::now();
+
+    // Get readings from position sensors (assumes 4)
+    double rr_pos = rr_odom->getValue();
+    double rl_pos = rl_odom->getValue();
+    double fr_pos = fr_odom->getValue();
+    double fl_pos = fl_odom->getValue();
+
+    // Take average of each side
+    double r_pos = (rr_pos + rl_pos) / 2;
+    double l_pos = (fr_pos + fl_pos) / 2;
+
+    // Calculate linear velocity from positions
+    double robot_vel = calcLinearVelocity(r_pos, l_pos, curr_time);
+
+    // Publish ground truth (which is still kinda noisy)
+    geometry_msgs::TwistWithCovarianceStamped gt;
+    gt.header.stamp = ros::Time::now();
+    gt.header.frame_id = "base_link";
+    gt.twist.twist.linear.x = robot_vel;
+    ground_truth_pub.publish(gt);
+
+    // Add noise to readings
+    double noisy_rr_pos = rr_pos + gaussianNoise();
+    double noisy_rl_pos = rl_pos + gaussianNoise();
+    double noisy_fr_pos = fr_pos + gaussianNoise();
+    double noisy_fl_pos = fl_pos + gaussianNoise();
+
+    // Take average of each side
+    double noisy_r_pos = (noisy_rr_pos + noisy_rl_pos) / 2;
+    double noisy_l_pos = (noisy_fr_pos + noisy_fl_pos) / 2;
+
+    // Calculate linear velocity from positions
+    double noisy_robot_vel = calcLinearVelocity(noisy_r_pos, noisy_l_pos, curr_time);
+
+    // Publish noisy data (which even more noisy than gt)
+    geometry_msgs::TwistWithCovarianceStamped msg;
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = "base_link";
+    msg.twist.twist.linear.x = noisy_robot_vel;
+    noise_pub.publish(msg);
+
+    // Save current state for next time
+    prev_l_pos = l_pos;
+    prev_r_pos = r_pos;
+    prev_time = curr_time;
+}
+
+double WheelOdom::calcLinearVelocity(double r_pos, double l_pos, ros::Time curr_time)
+{
+    // Calculate average angular velocity between two consecutive time stamps
+    double r_avel = (r_pos - prev_r_pos) / (curr_time - prev_time).toSec();
+    double l_avel = (l_pos - prev_l_pos) / (curr_time - prev_time).toSec();
+
+    // Convert to linear velocity
+    double r_vel = r_avel * wheel_radius;
+    double l_vel = l_avel * wheel_radius;
+
+    // Calculate linear and rotational velocity of robot
+    return (l_vel + r_vel) / 2;
+}
+
+double WheelOdom::gaussianNoise()
+{
+    std::normal_distribution<double> d{noise_mean, noise_std};
+    return d(*gen);
+}

--- a/lib/sensors/src/wheelOdom.cpp
+++ b/lib/sensors/src/wheelOdom.cpp
@@ -47,6 +47,8 @@ WheelOdom::WheelOdom(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros
     // Initalize position values
     prev_r_pos = 0;
     prev_l_pos = 0;
+    prev_noisy_r_pos = 0;
+    prev_noisy_l_pos = 0;
     prev_time = ros::Time::now();
 
     // Initialize generator with seed

--- a/lib/sensors/src/wheelOdom.cpp
+++ b/lib/sensors/src/wheelOdom.cpp
@@ -77,8 +77,8 @@ void WheelOdom::publishWheelOdom()
     double fl_pos = fl_odom->getValue();
 
     // Take average of each side
-    double r_pos = (rr_pos + rl_pos) / 2;
-    double l_pos = (fr_pos + fl_pos) / 2;
+    double r_pos = (rr_pos + fr_pos) / 2;
+    double l_pos = (rl_pos + fl_pos) / 2;
 
     // Calculate linear velocity from positions
     double robot_vel = calcLinearVelocity(r_pos, l_pos, curr_time);
@@ -97,8 +97,8 @@ void WheelOdom::publishWheelOdom()
     double noisy_fl_pos = fl_pos + gaussianNoise();
 
     // Take average of each side
-    double noisy_r_pos = (noisy_rr_pos + noisy_rl_pos) / 2;
-    double noisy_l_pos = (noisy_fr_pos + noisy_fl_pos) / 2;
+    double noisy_r_pos = (noisy_rr_pos + noisy_fr_pos) / 2;
+    double noisy_l_pos = (noisy_rl_pos + noisy_fl_pos) / 2;
 
     // Calculate linear velocity from positions
     double noisy_robot_vel = calcLinearVelocity(noisy_r_pos, noisy_l_pos, curr_time);
@@ -108,6 +108,7 @@ void WheelOdom::publishWheelOdom()
     msg.header.stamp = ros::Time::now();
     msg.header.frame_id = "base_link";
     msg.twist.twist.linear.x = noisy_robot_vel;
+    msg.twist.covariance[0] = std::pow(noise_mean + noise_std, 2);
     noise_pub.publish(msg);
 
     // Save current state for next time
@@ -126,7 +127,7 @@ double WheelOdom::calcLinearVelocity(double r_pos, double l_pos, ros::Time curr_
     double r_vel = r_avel * wheel_radius;
     double l_vel = l_avel * wheel_radius;
 
-    // Calculate linear and rotational velocity of robot
+    // Calculate linear velocity of robot
     return (l_vel + r_vel) / 2;
 }
 

--- a/lib/sensors/src/wheelOdom.cpp
+++ b/lib/sensors/src/wheelOdom.cpp
@@ -86,7 +86,7 @@ void WheelOdom::publishWheelOdom()
     double dr = r_pos - prev_r_pos;
     double dl = l_pos - prev_l_pos;
 
-    // Calculate linear velocity from positions
+    // Calculate linear velocity from change in angle
     double robot_vel = calcLinearVelocity(dr, dl, curr_time);
 
     // Publish ground truth (which is still kinda noisy)
@@ -110,7 +110,7 @@ void WheelOdom::publishWheelOdom()
     double noisy_dr = noisy_r_pos - prev_noisy_r_pos;
     double noisy_dl = noisy_l_pos - prev_noisy_l_pos;
 
-    // Calculate linear velocity from positions
+    // Calculate linear velocity from change in angle
     double noisy_robot_vel = calcLinearVelocity(noisy_dr, noisy_dl, curr_time);
 
     // Publish noisy data (which even more noisy than gt)

--- a/lib/steering/include/steering/diffSteering.hpp
+++ b/lib/steering/include/steering/diffSteering.hpp
@@ -19,8 +19,6 @@ namespace AutomatED
     std::vector<webots::Motor *> wheels;
     ros::NodeHandle *nh;
     int wheel_count;
-    double linear_vel;
-    double angular_vel;
 
     // ROS Parameters
     std::string frame_id;
@@ -28,29 +26,9 @@ namespace AutomatED
     std::string noise_topic;
     double wheel_separation;
     double wheel_radius;
-    double linear_mean;
-    double linear_std;
-    double linear_bias_mean;
-    double linear_bias_std;
-    double angular_mean;
-    double angular_std;
-    double angular_bias_mean;
-    double angular_bias_std;
-    int noise_seed;
-
-    // ROS publisher
-    ros::Publisher ground_truth_pub;
-    ros::Publisher noise_pub;
 
     // ROS Subscriber
     ros::Subscriber cmd_vel_sub;
-
-    // Noise
-    std::mt19937 *gen;
-    double linearGaussianNoise();
-    double angularGaussianNoise();
-    double linear_bias;
-    double angular_bias;
 
     void velocityCallback(const geometry_msgs::TwistConstPtr &cmd);
     void stopMotors();

--- a/lib/steering/src/diffSteering.cpp
+++ b/lib/steering/src/diffSteering.cpp
@@ -12,8 +12,6 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
   wheels = motors;
   nh = ros_handle;
   wheel_count = wheels.size();
-  linear_vel = 0;
-  angular_vel = 0;
 
   // Get ROS parameters
   nh->param<std::string>("wheel_odom/frame_id", frame_id, "base_link");
@@ -23,33 +21,10 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
                          "/wheel_odom/data");
   nh->param("wheel_separation", wheel_separation, 0.6);
   nh->param("wheel_radius", wheel_radius, 0.12);
-  nh->param("wheel_odom/linear_mean", linear_mean, 0.0);
-  nh->param("wheel_odom/linear_std", linear_std, 0.017);
-  nh->param("wheel_odom/linear_bias_mean", linear_bias_mean, 0.1);
-  nh->param("wheel_odom/linear_bias_std", linear_bias_std, 0.001);
-  nh->param("wheel_odom/angular_mean", angular_mean, 0.0);
-  nh->param("wheel_odom/angular_std", angular_std, 0.0002);
-  nh->param("wheel_odom/angular_bias_mean", angular_bias_mean, 0.0000075);
-  nh->param("wheel_odom/angular_bias_std", angular_bias_std, 0.0000008);
-  nh->param<int>("wheel_odom/noise_seed", noise_seed, 17);
-
-  // Create publishers
-  ground_truth_pub =
-      nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(ground_truth_topic, 1);
-  noise_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(noise_topic, 1);
 
   // Create Subscriber
   cmd_vel_sub =
       nh->subscribe("/cmd_vel", 1, &DiffSteering::velocityCallback, this);
-
-  // Initialize generator with seed
-  gen = new std::mt19937{(long unsigned int)noise_seed};
-
-  // Sample bias
-  std::normal_distribution<double> dl{linear_bias_mean, linear_bias_std};
-  linear_bias = dl(*gen);
-  std::normal_distribution<double> da{angular_bias_mean, angular_bias_std};
-  angular_bias = da(*gen);
 
   // Turn on motors
   for (int i = 0; i < wheel_count; i++)
@@ -62,16 +37,14 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
 DiffSteering::~DiffSteering()
 {
   // Clean up
-  ground_truth_pub.shutdown();
-  noise_pub.shutdown();
   cmd_vel_sub.shutdown();
   stopMotors();
 }
 
 void DiffSteering::velocityCallback(const geometry_msgs::TwistConstPtr &cmd)
 {
-  linear_vel = cmd->linear.x;
-  angular_vel = cmd->angular.z;
+  double linear_vel = cmd->linear.x;
+  double angular_vel = cmd->angular.z;
 
   const double vel_left =
       (linear_vel - angular_vel * wheel_separation / 2.0) / wheel_radius;
@@ -86,43 +59,10 @@ void DiffSteering::velocityCallback(const geometry_msgs::TwistConstPtr &cmd)
   wheels[3]->setVelocity(vel_right);
 }
 
-void DiffSteering::publish()
-{
-  // Publish ground truth wheel odometry
-  geometry_msgs::TwistWithCovarianceStamped gt;
-  gt.header.stamp = ros::Time::now();
-  gt.header.frame_id = frame_id;
-  gt.twist.twist.linear.x = linear_vel;
-  gt.twist.twist.angular.z = angular_vel;
-  ground_truth_pub.publish(gt);
-
-  // Publish noisy wheel odometry data
-  geometry_msgs::TwistWithCovarianceStamped msg;
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = frame_id;
-  msg.twist.twist.linear.x = linear_vel + linear_bias + linearGaussianNoise();
-  msg.twist.twist.angular.z = angular_vel + angular_bias + angularGaussianNoise();
-  msg.twist.covariance[0] = std::pow(linear_bias + linear_mean + linear_std, 2);
-  msg.twist.covariance[35] = std::pow(angular_bias + angular_mean + angular_std, 2);
-  noise_pub.publish(msg);
-}
-
 void DiffSteering::stopMotors()
 {
   for (int i = 0; i < wheel_count; i++)
   {
     wheels[i]->setVelocity(0.0);
   }
-}
-
-double DiffSteering::linearGaussianNoise()
-{
-  std::normal_distribution<double> d{linear_mean, linear_std};
-  return d(*gen);
-}
-
-double DiffSteering::angularGaussianNoise()
-{
-  std::normal_distribution<double> d{angular_mean, angular_std};
-  return d(*gen);
 }

--- a/protos/StreetSmart.proto
+++ b/protos/StreetSmart.proto
@@ -190,7 +190,7 @@ PROTO StreetSmart [
           name "rear_right_wheel"
         }
         PositionSensor {
-          name rr_odom
+          name "rr_odom"
           noise 0   
           resolution -1
         }
@@ -248,7 +248,7 @@ PROTO StreetSmart [
           name "rear_left_wheel"
         }
         PositionSensor {
-          name rl_odom
+          name "rl_odom"
           noise 0   
           resolution -1
         }
@@ -276,7 +276,7 @@ PROTO StreetSmart [
           name "front_right_wheel"
         }
         PositionSensor {
-          name fr_odom
+          name "fr_odom"
           noise 0   
           resolution -1
         }
@@ -304,7 +304,7 @@ PROTO StreetSmart [
           name "front_left_wheel"
         }
         PositionSensor {
-          name fl_odom
+          name "fl_odom"
           noise 0   
           resolution -1
         }

--- a/protos/StreetSmart.proto
+++ b/protos/StreetSmart.proto
@@ -189,6 +189,11 @@ PROTO StreetSmart [
         RotationalMotor {
           name "rear_right_wheel"
         }
+        PositionSensor {
+          name rr_odom
+          noise 0   
+          resolution -1
+        }
       ]
       endPoint DEF REAR_RIGHT_SOLID Solid {
         translation -0.23 0 0.3
@@ -242,6 +247,11 @@ PROTO StreetSmart [
         RotationalMotor {
           name "rear_left_wheel"
         }
+        PositionSensor {
+          name rl_odom
+          noise 0   
+          resolution -1
+        }
       ]
       endPoint DEF REAR_LEFT_SOLID Solid {
         translation -0.23 0 -0.3
@@ -265,6 +275,11 @@ PROTO StreetSmart [
         RotationalMotor {
           name "front_right_wheel"
         }
+        PositionSensor {
+          name fr_odom
+          noise 0   
+          resolution -1
+        }
       ]
       endPoint DEF FRONT_RIGHT_SOLID Solid {
         translation 0.23 0 0.3
@@ -287,6 +302,11 @@ PROTO StreetSmart [
       device [
         RotationalMotor {
           name "front_left_wheel"
+        }
+        PositionSensor {
+          name fl_odom
+          noise 0   
+          resolution -1
         }
       ]
       endPoint DEF FRONT_LEFT_SOLID Solid {

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
   AutomatED::Gyro gyro = AutomatED::Gyro(supervisor, &nh);
   AutomatED::Accelerometer accelerometer =
       AutomatED::Accelerometer(supervisor, &nh);
-  AutomatED::WheelOdom wheel_odom(supervisor, &nh);
+  AutomatED::WheelOdom wheel_odom = AutomatED::WheelOdom(supervisor, &nh);
 
   // Instantiate steering
   AutomatED::DiffSteering diffSteering = AutomatED::DiffSteering(motors, &nh);

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -34,12 +34,6 @@ int main(int argc, char **argv)
       supervisor->getMotor("rear_left_wheel"),
       supervisor->getMotor("rear_right_wheel")};
 
-  // Turn on LEDs
-  supervisor->getLED("front_left_led")->set(1);
-  supervisor->getLED("front_right_led")->set(1);
-  supervisor->getLED("rear_left_led")->set(1);
-  supervisor->getLED("rear_right_led")->set(1);
-
   // Instantiate sensor wrappers
   AutomatED::Lidar lidar = AutomatED::Lidar(supervisor, &nh);
   AutomatED::GPS gps = AutomatED::GPS(supervisor, &nh);
@@ -53,10 +47,17 @@ int main(int argc, char **argv)
 
   // Instaniate keyboard steering
   AutomatED::KeyboardController *keyboard;
-  if (use_keyboard_control) {
+  if (use_keyboard_control)
+  {
     keyboard = new AutomatED::KeyboardController(supervisor, &nh);
   }
-  
+
+  // Turn on LEDs
+  supervisor->getLED("front_left_led")->set(1);
+  supervisor->getLED("front_right_led")->set(1);
+  supervisor->getLED("rear_left_led")->set(1);
+  supervisor->getLED("rear_right_led")->set(1);
+
   while (supervisor->step(step_size) != -1)
   {
     lidar.publishLaserScan();

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -4,6 +4,7 @@
 #include "sensors/gyro.hpp"
 #include "sensors/inertialUnit.hpp"
 #include "sensors/lidar.hpp"
+#include "sensors/wheelOdom.hpp"
 #include "steering/diffSteering.hpp"
 #include "utils/KeyboardController.hpp"
 #include "webots/Motor.hpp"
@@ -41,6 +42,7 @@ int main(int argc, char **argv)
   AutomatED::Gyro gyro = AutomatED::Gyro(supervisor, &nh);
   AutomatED::Accelerometer accelerometer =
       AutomatED::Accelerometer(supervisor, &nh);
+  AutomatED::WheelOdom wheel_odom(supervisor, &nh);
 
   // Instantiate steering
   AutomatED::DiffSteering diffSteering = AutomatED::DiffSteering(motors, &nh);
@@ -65,7 +67,7 @@ int main(int argc, char **argv)
     imu.publishImuQuaternion();
     gyro.publishGyro();
     accelerometer.publishAccelerometer();
-    diffSteering.publish();
+    wheel_odom.publishWheelOdom();
 
     if (use_keyboard_control)
     {


### PR DESCRIPTION
This PR adds a [Webots PositionSensor](https://www.cyberbotics.com/doc/reference/positionsensor?tab-language=c++#wb_position_sensor_disable) to each wheel of the robot model. This allows us to calculate the linear velocity of the robot by taking the difference in the angle of each wheel from the previous time step and dividing by the time passed.

This implementation replaces the previous implementation we had of adding noise to the commands received by `diffSteering` as this was not good practice and not how we would obtain this information in real life.

Couple things to note with this implementation:
1. If you print the value returned by each of the four sensors while moving the robot forwards and backwards, you'll notice that the back two and the front two match (but the front and back do not). If you drive AND turn the robot, all four sensors gradually seem to diverge. Not sure if this is a problem or not (the ground truth velocity seems pretty stable).
2. the ground truth data (published to `/wheel_odom/ground_truth`) is rather noisy. I think this is kind of expected but it may be because of 1.

If we look at a graph of the noisy linear velocity over time, it seems to be quite stable (you can't see the ground truth data because it's being covered by the red noisy data):
![Screenshot from 2021-03-16 02-31-44](https://user-images.githubusercontent.com/38025909/111247446-e2040100-85ff-11eb-94dc-2d68f9e9450c.png)
