### PR TITLE
Fix sensors for localization

### DIFF
--- a/lib/sensors/include/sensors/accelerometer.hpp
+++ b/lib/sensors/include/sensors/accelerometer.hpp
@@ -32,8 +32,6 @@ namespace AutomatED
     std::string noise_topic;
     double noise_mean;
     double noise_std;
-    double bias_mean;
-    double bias_std;
     int noise_seed;
 
     // ROS publisher
@@ -47,7 +45,6 @@ namespace AutomatED
     // Noise
     std::mt19937 *gen;
     double gaussianNoise();
-    double bias;
   };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/gps.hpp
+++ b/lib/sensors/include/sensors/gps.hpp
@@ -30,8 +30,6 @@ namespace AutomatED
     std::string coordinate_topic;
     double noise_mean;
     double noise_std;
-    double bias_mean;
-    double bias_std;
     int noise_seed;
 
     // ROS publishers
@@ -45,7 +43,6 @@ namespace AutomatED
     // Noise
     std::mt19937 *gen;
     double gaussianNoise();
-    double bias;
   };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/gyro.hpp
+++ b/lib/sensors/include/sensors/gyro.hpp
@@ -31,8 +31,6 @@ namespace AutomatED
     std::string noise_topic;
     double noise_mean;
     double noise_std;
-    double bias_mean;
-    double bias_std;
     int noise_seed;
 
     // ROS publisher
@@ -46,7 +44,6 @@ namespace AutomatED
     // Noise
     std::mt19937 *gen;
     double gaussianNoise();
-    double bias;
   };
 
 } // namespace AutomatED

--- a/lib/sensors/include/sensors/inertialUnit.hpp
+++ b/lib/sensors/include/sensors/inertialUnit.hpp
@@ -32,8 +32,6 @@ namespace AutomatED
     std::string noise_topic;
     double noise_mean;
     double noise_std;
-    double bias_mean;
-    double bias_std;
     int noise_seed;
 
     // ROS publisher
@@ -47,7 +45,6 @@ namespace AutomatED
     // Noise
     std::mt19937 *gen;
     double gaussianNoise();
-    double bias;
   };
 
 } // namespace AutomatED

--- a/lib/sensors/src/accelerometer.cpp
+++ b/lib/sensors/src/accelerometer.cpp
@@ -61,6 +61,11 @@ void Accelerometer::publishAccelerometer()
   // Read from sensor
   const double *reading = accelerometer->getValues();
 
+  // Extract data
+  double webots_x = reading[0];
+  double webots_y = reading[1];
+  double webots_z = reading[2];
+
   // Publish ground truth
   sensor_msgs::Imu gt;
   gt.header.stamp = ros::Time::now();
@@ -69,88 +74,32 @@ void Accelerometer::publishAccelerometer()
   // Unset values are set to 0 by default
   gt.orientation_covariance[0] = -1.0; // means no orientation information
   gt.angular_velocity_covariance[0] = -1.0; // no angular_velocity information
-  gt.linear_acceleration.x = reading[0];
-  gt.linear_acceleration.y = reading[1];
-  gt.linear_acceleration.z = reading[2];
+  gt.linear_acceleration.x = webots_x;
+  gt.linear_acceleration.y = 0;
+  gt.linear_acceleration.z = 0;
 
   for (int i = 0; i < 9; i++) // means "covariance unknown"
     gt.linear_acceleration_covariance[i] = 0;
 
   ground_truth_pub.publish(gt);
-
-  // Publish noisy data
-  sensor_msgs::Imu msg;
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = frame_id;
-
-  // Unset values are set to 0 by default
-  msg.orientation_covariance[0] = -1;      // means no orientation information
-  msg.angular_velocity_covariance[0] = -1; // no angular_velocity information
-  msg.linear_acceleration.x = reading[0] + bias + gaussianNoise();
-  msg.linear_acceleration.y = reading[1] + bias + gaussianNoise();
-  msg.linear_acceleration.z = reading[2] + bias + gaussianNoise();
-
-  // Populate variance along the diagonal
-  msg.linear_acceleration_covariance[0] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.linear_acceleration_covariance[4] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.linear_acceleration_covariance[8] = std::pow(bias + noise_mean + noise_std, 2);
-
-  noise_pub.publish(msg);
 }
 
 void Accelerometer::publishTF()
 {
-  // Get accelerometer node
-  webots::Node *accelerometer_node = wb->getFromDevice(accelerometer);
-
-  // Get accelerometer translation
-  webots::Field *accelerometer_translation_field =
-      accelerometer_node->getField("translation");
-  const double *accelerometer_translation =
-      accelerometer_translation_field->getSFVec3f();
-
-  ROS_DEBUG("Accelerometer translation: [%f, %f, %f]",
-            accelerometer_translation[0],
-            accelerometer_translation[1],
-            accelerometer_translation[2]);
-
-  // Get accelerometer rotation
-  webots::Field *accelerometer_rotation_field =
-      accelerometer_node->getField("rotation");
-  const double *accelerometer_rotation =
-      accelerometer_rotation_field->getSFRotation();
-
-  ROS_DEBUG("Accelerometer rotation: [%f, %f, %f, %f]",
-            accelerometer_rotation[0],
-            accelerometer_rotation[1],
-            accelerometer_rotation[2],
-            accelerometer_rotation[3]);
-
   // Create transform msg
   geometry_msgs::TransformStamped msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "base_link";
   msg.child_frame_id = frame_id;
 
-  // Translate from ROS to Webots coordinates
-  msg.transform.translation.x = accelerometer_translation[0];
-  msg.transform.translation.y = -1 * accelerometer_translation[2];
-  msg.transform.translation.z = accelerometer_translation[1];
+  msg.transform.translation.x = 0;
+  msg.transform.translation.y = 0;
+  msg.transform.translation.z = 0;
 
-  tf2::Quaternion rot;
-  rot.setRotation({accelerometer_rotation[0],
-                   accelerometer_rotation[1],
-                   accelerometer_rotation[2]}, accelerometer_rotation[3]);
-
-  tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5708, 0, 0);
-
-  tf2::Quaternion quat = ros_to_webots * rot;
-  quat.normalize();
-  msg.transform.rotation.x = quat.x();
-  msg.transform.rotation.y = quat.y();
-  msg.transform.rotation.z = quat.z();
-  msg.transform.rotation.w = quat.w();
+  msg.transform.rotation.x = 0;
+  msg.transform.rotation.y = 0;
+  msg.transform.rotation.z = 0;
+  msg.transform.rotation.w = 1;
 
   static_broadcaster.sendTransform(msg);
 }

--- a/lib/sensors/src/gps.cpp
+++ b/lib/sensors/src/gps.cpp
@@ -67,67 +67,29 @@ void GPS::publishGPSCoordinate()
   gt.header.stamp = ros::Time::now();
   gt.header.frame_id = frame_id;
   gt.latitude = reading[0];
-  gt.longitude = reading[2];
-  gt.altitude = reading[1];
+  gt.longitude = reading[1];
+  gt.altitude = reading[2];
   gt.position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
   gt.status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
   gt_coordinate_pub.publish(gt);
-
-  // Publish data with noise
-  sensor_msgs::NavSatFix msg;
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = frame_id;
-  msg.latitude = reading[0] + bias + gaussianNoise();
-  msg.longitude = reading[2] + bias + gaussianNoise();
-  msg.altitude = reading[1] + bias + gaussianNoise();
-  msg.position_covariance_type =
-      sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
-  // Populate variance along the diagonal
-  msg.position_covariance[0] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.position_covariance[4] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.position_covariance[8] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
-  coordinate_pub.publish(msg);
 }
 
 void GPS::publishTF()
 {
-  // Get gps node
-  webots::Node *gps_node = wb->getFromDevice(gps);
-
-  // Get gps translation
-  webots::Field *gps_translation_field = gps_node->getField("translation");
-  const double *gps_translation = gps_translation_field->getSFVec3f();
-
-  // Get gps rotation
-  webots::Field *gps_rotation_field = gps_node->getField("rotation");
-  const double *gps_rotation = gps_rotation_field->getSFRotation();
-
   // Create transform msg
   geometry_msgs::TransformStamped msg;
   msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "odom";
+  msg.header.frame_id = "base_link";
   msg.child_frame_id = frame_id;
 
-  // Translate from Webots to ROS coordinates
-  msg.transform.translation.x = gps_translation[0];
-  msg.transform.translation.y = -1 * gps_translation[2];
-  msg.transform.translation.z = gps_translation[1];
+  msg.transform.translation.x = 0;
+  msg.transform.translation.y = 0;
+  msg.transform.translation.z = 0;
 
-  tf2::Quaternion rot;
-  rot[0] = gps_rotation[1];
-  rot[1] = gps_rotation[2];
-  rot[2] = gps_rotation[3];
-  rot[3] = gps_rotation[0];
-
-  tf2::Quaternion webots_to_ros;
-  webots_to_ros.setRPY(-1.5707, 0, 0);
-
-  tf2::Quaternion quat = webots_to_ros * rot;
-  msg.transform.rotation.x = quat.x();
-  msg.transform.rotation.y = quat.y();
-  msg.transform.rotation.z = quat.z();
-  msg.transform.rotation.w = quat.w();
+  msg.transform.rotation.x = 0;
+  msg.transform.rotation.y = 0;
+  msg.transform.rotation.z = 0;
+  msg.transform.rotation.w = 1;
 
   static_broadcaster.sendTransform(msg);
 }

--- a/lib/sensors/src/gyro.cpp
+++ b/lib/sensors/src/gyro.cpp
@@ -57,6 +57,11 @@ void Gyro::publishGyro()
   // Get data from Gyro
   const double *reading = gyro->getValues();
 
+  // Extract data
+  double webots_x = reading[0];
+  double webots_y = reading[1];
+  double webots_z = reading[2];
+
   // Publish ground truth
   sensor_msgs::Imu gt;
   gt.header.stamp = ros::Time::now();
@@ -64,81 +69,30 @@ void Gyro::publishGyro()
 
   // Unset values are set to 0 by default
   gt.orientation_covariance[0] = -1.0; // means no orientation information
-  gt.angular_velocity.x = reading[0];
-  gt.angular_velocity.y = reading[1];
-  gt.angular_velocity.z = reading[2];
+  gt.angular_velocity.x = 0;
+  gt.angular_velocity.y = 0;
+  gt.angular_velocity.z = webots_y;
   gt.linear_acceleration_covariance[0] = -1.0; // means no information
 
   ground_truth_pub.publish(gt);
-
-  // Publish noisy data
-  sensor_msgs::Imu msg;
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = frame_id;
-
-  // Unset values are set to 0 by default
-  msg.orientation_covariance[0] = -1.0; // means no orientation information
-  msg.angular_velocity.x = reading[0] + bias + gaussianNoise();
-  msg.angular_velocity.y = reading[1] + bias + gaussianNoise();
-  msg.angular_velocity.z = reading[2] + bias + gaussianNoise();
-  // Populate variance along the diagonal
-  msg.angular_velocity_covariance[0] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.angular_velocity_covariance[4] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.angular_velocity_covariance[8] = std::pow(bias + noise_mean + noise_std, 2);
-  msg.linear_acceleration_covariance[0] = -1.0; // means no lin acc information
-
-  noise_pub.publish(msg);
 }
 
 void Gyro::publishTF()
 {
-  // Get gyro node
-  webots::Node *gyro_node = wb->getFromDevice(gyro);
-
-  // Get gyro translation
-  webots::Field *gyro_translation_field = gyro_node->getField("translation");
-  const double *gyro_translation = gyro_translation_field->getSFVec3f();
-
-  ROS_DEBUG("Gyro translation: [%f, %f, %f]",
-            gyro_translation[0],
-            gyro_translation[1],
-            gyro_translation[2]);
-
-  // Get gyro rotation
-  webots::Field *gyro_rotation_field = gyro_node->getField("rotation");
-  const double *gyro_rotation = gyro_rotation_field->getSFRotation();
-
-  ROS_DEBUG("Gyro rotation: [%f, %f, %f, %f]",
-            gyro_rotation[0],
-            gyro_rotation[1],
-            gyro_rotation[2],
-            gyro_rotation[3]);
-
   // Create transform msg
   geometry_msgs::TransformStamped msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "base_link";
   msg.child_frame_id = frame_id;
 
-  // Translate from ROS to Webots coordinates
-  msg.transform.translation.x = gyro_translation[0];
-  msg.transform.translation.y = -1 * gyro_translation[2];
-  msg.transform.translation.z = gyro_translation[1];
+  msg.transform.translation.x = 0;
+  msg.transform.translation.y = 0;
+  msg.transform.translation.z = 0;
 
-  tf2::Quaternion rot;
-  rot.setRotation({gyro_rotation[0],
-                   gyro_rotation[1],
-                   gyro_rotation[2]}, gyro_rotation[3]);
-
-  tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5708, 0, 0);
-
-  tf2::Quaternion quat = ros_to_webots * rot;
-  quat.normalize();
-  msg.transform.rotation.x = quat.x();
-  msg.transform.rotation.y = quat.y();
-  msg.transform.rotation.z = quat.z();
-  msg.transform.rotation.w = quat.w();
+  msg.transform.rotation.x = 0;
+  msg.transform.rotation.y = 0;
+  msg.transform.rotation.z = 0;
+  msg.transform.rotation.w = 1;
 
   static_broadcaster.sendTransform(msg);
 }

--- a/lib/sensors/src/lidar.cpp
+++ b/lib/sensors/src/lidar.cpp
@@ -19,7 +19,7 @@ Lidar::Lidar(webots::Supervisor *webots_supervisor,
 
   // Get ROS parameters
   nh->param<std::string>("lidar/name", lidar_name, "RobotisLds01");
-  nh->param<std::string>("lidar/name", frame_id, "lidar");
+  nh->param<std::string>("lidar/frame_id", frame_id, "lidar");
   nh->param("lidar/sampling_period", sampling_period, 32);
   nh->param<std::string>("lidar/ground_truth_topic", ground_truth_topic,
                          "/lidar/ground_truth");
@@ -116,52 +116,20 @@ void Lidar::publishLaserScan()
 
 void Lidar::publishTF()
 {
-  // Get lidar node
-  webots::Node *lidar_node = wb->getFromDevice(lidar);
-
-  // Get lidar translation
-  webots::Field *lidar_translation_field = lidar_node->getField("translation");
-  const double *lidar_translation = lidar_translation_field->getSFVec3f();
-
-  ROS_DEBUG("Lidar translation: [%f, %f, %f]",
-           lidar_translation[0],
-           lidar_translation[1],
-           lidar_translation[2]);
-
-  // Get lidar rotation
-  webots::Field *lidar_rotation_field = lidar_node->getField("rotation");
-  const double *lidar_rotation = lidar_rotation_field->getSFRotation();
-
-  ROS_DEBUG("Lidar rotation: [%f, %f, %f, %f]",
-           lidar_rotation[0],
-           lidar_rotation[1],
-           lidar_rotation[2],
-           lidar_rotation[3]);
-
   // Create transform msg
   geometry_msgs::TransformStamped msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "base_link";
   msg.child_frame_id = frame_id;
 
-  // Translate from Webots to ROS coordinates
-  msg.transform.translation.x = lidar_translation[0];
-  msg.transform.translation.y = -1 * lidar_translation[2];
-  msg.transform.translation.z = lidar_translation[1];
+  msg.transform.translation.x = 0;
+  msg.transform.translation.y = 0;
+  msg.transform.translation.z = 0;
 
-  tf2::Quaternion rot;
-  rot.setRotation({lidar_rotation[0],
-                   lidar_rotation[1],
-                   lidar_rotation[2]}, lidar_rotation[3]);
-
-  tf2::Quaternion ros_to_webots;
-  ros_to_webots.setRPY(1.5708, 0, 0);
-
-  tf2::Quaternion quat = ros_to_webots * rot;
-  msg.transform.rotation.x = quat.x();
-  msg.transform.rotation.y = quat.y();
-  msg.transform.rotation.z = quat.z();
-  msg.transform.rotation.w = quat.w();
+  msg.transform.rotation.x = 0;
+  msg.transform.rotation.y = 0;
+  msg.transform.rotation.z = 0;
+  msg.transform.rotation.w = 1;
 
   static_broadcaster.sendTransform(msg);
 }

--- a/lib/steering/include/steering/diffSteering.hpp
+++ b/lib/steering/include/steering/diffSteering.hpp
@@ -19,8 +19,6 @@ namespace AutomatED
     std::vector<webots::Motor *> wheels;
     ros::NodeHandle *nh;
     int wheel_count;
-    double linear_vel;
-    double angular_vel;
 
     // ROS Parameters
     std::string frame_id;
@@ -28,15 +26,6 @@ namespace AutomatED
     std::string noise_topic;
     double wheel_separation;
     double wheel_radius;
-    double linear_mean;
-    double linear_std;
-    double linear_bias_mean;
-    double linear_bias_std;
-    double angular_mean;
-    double angular_std;
-    double angular_bias_mean;
-    double angular_bias_std;
-    int noise_seed;
 
     // ROS publisher
     ros::Publisher ground_truth_pub;
@@ -44,13 +33,6 @@ namespace AutomatED
 
     // ROS Subscriber
     ros::Subscriber cmd_vel_sub;
-
-    // Noise
-    std::mt19937 *gen;
-    double linearGaussianNoise();
-    double angularGaussianNoise();
-    double linear_bias;
-    double angular_bias;
 
     void velocityCallback(const geometry_msgs::TwistConstPtr &cmd);
     void stopMotors();

--- a/lib/steering/src/diffSteering.cpp
+++ b/lib/steering/src/diffSteering.cpp
@@ -12,8 +12,6 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
   wheels = motors;
   nh = ros_handle;
   wheel_count = wheels.size();
-  linear_vel = 0;
-  angular_vel = 0;
 
   // Get ROS parameters
   nh->param<std::string>("wheel_odom/frame_id", frame_id, "base_link");
@@ -23,15 +21,6 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
                          "/wheel_odom/data");
   nh->param("wheel_separation", wheel_separation, 0.6);
   nh->param("wheel_radius", wheel_radius, 0.12);
-  nh->param("wheel_odom/linear_mean", linear_mean, 0.0);
-  nh->param("wheel_odom/linear_std", linear_std, 0.017);
-  nh->param("wheel_odom/linear_bias_mean", linear_bias_mean, 0.1);
-  nh->param("wheel_odom/linear_bias_std", linear_bias_std, 0.001);
-  nh->param("wheel_odom/angular_mean", angular_mean, 0.0);
-  nh->param("wheel_odom/angular_std", angular_std, 0.0002);
-  nh->param("wheel_odom/angular_bias_mean", angular_bias_mean, 0.0000075);
-  nh->param("wheel_odom/angular_bias_std", angular_bias_std, 0.0000008);
-  nh->param<int>("wheel_odom/noise_seed", noise_seed, 17);
 
   // Create publishers
   ground_truth_pub =
@@ -41,15 +30,6 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
   // Create Subscriber
   cmd_vel_sub =
       nh->subscribe("/cmd_vel", 1, &DiffSteering::velocityCallback, this);
-
-  // Initialize generator with seed
-  gen = new std::mt19937{(long unsigned int)noise_seed};
-
-  // Sample bias
-  std::normal_distribution<double> dl{linear_bias_mean, linear_bias_std};
-  linear_bias = dl(*gen);
-  std::normal_distribution<double> da{angular_bias_mean, angular_bias_std};
-  angular_bias = da(*gen);
 
   // Turn on motors
   for (int i = 0; i < wheel_count; i++)
@@ -70,8 +50,8 @@ DiffSteering::~DiffSteering()
 
 void DiffSteering::velocityCallback(const geometry_msgs::TwistConstPtr &cmd)
 {
-  linear_vel = cmd->linear.x;
-  angular_vel = cmd->angular.z;
+  double linear_vel = cmd->linear.x;
+  double angular_vel = cmd->angular.z;
 
   const double vel_left =
       (linear_vel - angular_vel * wheel_separation / 2.0) / wheel_radius;
@@ -86,43 +66,10 @@ void DiffSteering::velocityCallback(const geometry_msgs::TwistConstPtr &cmd)
   wheels[3]->setVelocity(vel_right);
 }
 
-void DiffSteering::publish()
-{
-  // Publish ground truth wheel odometry
-  geometry_msgs::TwistWithCovarianceStamped gt;
-  gt.header.stamp = ros::Time::now();
-  gt.header.frame_id = frame_id;
-  gt.twist.twist.linear.x = linear_vel;
-  gt.twist.twist.angular.z = angular_vel;
-  ground_truth_pub.publish(gt);
-
-  // Publish noisy wheel odometry data
-  geometry_msgs::TwistWithCovarianceStamped msg;
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = frame_id;
-  msg.twist.twist.linear.x = linear_vel + linear_bias + linearGaussianNoise();
-  msg.twist.twist.angular.z = angular_vel + angular_bias + angularGaussianNoise();
-  msg.twist.covariance[0] = std::pow(linear_bias + linear_mean + linear_std, 2);
-  msg.twist.covariance[35] = std::pow(angular_bias + angular_mean + angular_std, 2);
-  noise_pub.publish(msg);
-}
-
 void DiffSteering::stopMotors()
 {
   for (int i = 0; i < wheel_count; i++)
   {
     wheels[i]->setVelocity(0.0);
   }
-}
-
-double DiffSteering::linearGaussianNoise()
-{
-  std::normal_distribution<double> d{linear_mean, linear_std};
-  return d(*gen);
-}
-
-double DiffSteering::angularGaussianNoise()
-{
-  std::normal_distribution<double> d{angular_mean, angular_std};
-  return d(*gen);
 }

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -57,7 +57,6 @@ int main(int argc, char **argv)
     imu.publishImuQuaternion();
     gyro.publishGyro();
     accelerometer.publishAccelerometer();
-    diffSteering.publish();
 
     if (use_keyboard_control)
     {

--- a/worlds/curved_path.wbt
+++ b/worlds/curved_path.wbt
@@ -1,6 +1,8 @@
 #VRML_SIM R2021a utf8
 WorldInfo {
   coordinateSystem "NUE"
+  gpsCoordinateSystem "WGS84"
+  gpsReference 50 0 0
 }
 Viewpoint {
   orientation -0.9975388412005999 -0.062016891528195436 -0.032713383520270735 0.9728315267131853

--- a/worlds/rectangle.wbt
+++ b/worlds/rectangle.wbt
@@ -1,6 +1,8 @@
 #VRML_SIM R2021a utf8
 WorldInfo {
   coordinateSystem "NUE"
+  gpsCoordinateSystem "WGS84"
+  gpsReference 50 0 0
 }
 Viewpoint {
   orientation 0.9309067421470015 -0.28648941798319494 -0.22657548589577453 4.8746988518188035

--- a/worlds/square.wbt
+++ b/worlds/square.wbt
@@ -1,6 +1,8 @@
 #VRML_SIM R2021a utf8
 WorldInfo {
   coordinateSystem "NUE"
+  gpsCoordinateSystem "WGS84"
+  gpsReference 50 0 0
 }
 Viewpoint {
   orientation 0.8241432530809494 -0.5656974858396937 -0.027825400550569736 6.163959687501386

--- a/worlds/straight_line.wbt
+++ b/worlds/straight_line.wbt
@@ -1,6 +1,8 @@
 #VRML_SIM R2021a utf8
 WorldInfo {
   coordinateSystem "NUE"
+  gpsCoordinateSystem "WGS84"
+  gpsReference 50 0 0
 }
 Viewpoint {
   orientation -0.9883596528653996 -0.13802164869986835 -0.06399391438220321 0.8772664613010834

--- a/worlds/triangle.wbt
+++ b/worlds/triangle.wbt
@@ -1,6 +1,8 @@
 #VRML_SIM R2021a utf8
 WorldInfo {
   coordinateSystem "NUE"
+  gpsCoordinateSystem "WGS84"
+  gpsReference 50 0 0
 }
 Viewpoint {
   orientation 0.9113685411687799 0.39270023148399746 0.12326358083515525 5.6198074471793396


### PR DESCRIPTION
The changes made in https://github.com/automat-ed/simulation/pull/44 was still found to be problematic. This PR looks to fix these bugs to enable `robot_localization` to work properly.

The changes include:
1. Removing the bias feature in the noisy publishers. This was not a bug, per se, but rather something I removed because I thought it was not necessary. In real life, we would ideally calibrate the sensors to remove any such bias.
2. Removing any transforms. All transforms for the sensors should be zero. Instead, before we publish any data, we apply the transformations necessary to convert from Webots' coordinate frame to ROS'.