### PR TITLE
Remove topic parameters

### DIFF
--- a/lib/sensors/include/sensors/accelerometer.hpp
+++ b/lib/sensors/include/sensors/accelerometer.hpp
@@ -28,8 +28,6 @@ namespace AutomatED
     std::string accelerometer_name;
     std::string frame_id;
     int sampling_period;
-    std::string ground_truth_topic;
-    std::string noise_topic;
     double noise_mean;
     double noise_std;
     int noise_seed;

--- a/lib/sensors/include/sensors/gps.hpp
+++ b/lib/sensors/include/sensors/gps.hpp
@@ -26,8 +26,6 @@ namespace AutomatED
     std::string gps_name;
     std::string frame_id;
     int sampling_period;
-    std::string gt_coordinate_topic;
-    std::string coordinate_topic;
     double noise_mean;
     double noise_std;
     int noise_seed;

--- a/lib/sensors/include/sensors/gyro.hpp
+++ b/lib/sensors/include/sensors/gyro.hpp
@@ -27,8 +27,6 @@ namespace AutomatED
     std::string gyro_name;
     std::string frame_id;
     int sampling_period;
-    std::string ground_truth_topic;
-    std::string noise_topic;
     double noise_mean;
     double noise_std;
     int noise_seed;

--- a/lib/sensors/include/sensors/inertialUnit.hpp
+++ b/lib/sensors/include/sensors/inertialUnit.hpp
@@ -28,8 +28,6 @@ namespace AutomatED
     std::string imu_name;
     std::string frame_id;
     int sampling_period;
-    std::string ground_truth_topic;
-    std::string noise_topic;
     double noise_mean;
     double noise_std;
     int noise_seed;

--- a/lib/sensors/include/sensors/lidar.hpp
+++ b/lib/sensors/include/sensors/lidar.hpp
@@ -27,8 +27,6 @@ namespace AutomatED
     std::string lidar_name;
     std::string frame_id;
     int sampling_period;
-    std::string ground_truth_topic;
-    std::string noise_topic;
     double noise_mean;
     double noise_std;
     int noise_seed;

--- a/lib/sensors/include/sensors/wheelOdom.hpp
+++ b/lib/sensors/include/sensors/wheelOdom.hpp
@@ -40,8 +40,6 @@ namespace AutomatED
         std::string fl_name;
         std::string frame_id;
         int sampling_period;
-        std::string ground_truth_topic;
-        std::string noise_topic;
         double noise_mean;
         double noise_std;
         int noise_seed;

--- a/lib/sensors/src/accelerometer.cpp
+++ b/lib/sensors/src/accelerometer.cpp
@@ -20,17 +20,13 @@ Accelerometer::Accelerometer(webots::Supervisor *webots_supervisor,
                          "accelerometer");
   nh->param<std::string>("accelerometer/frame_id", frame_id, "accelerometer");
   nh->param("accelerometer/sampling_period", sampling_period, 32);
-  nh->param<std::string>("accelerometer/ground_truth_topic", ground_truth_topic,
-                         "/accelerometer/ground_truth");
-  nh->param<std::string>("accelerometer/noise_topic", noise_topic,
-                         "/accelerometer/data");
   nh->param("accelerometer/noise_mean", noise_mean, 0.0);
   nh->param("accelerometer/noise_std", noise_std, 0.017);
   nh->param<int>("accelerometer/noise_seed", noise_seed, 17);
 
   // Create publishers
-  ground_truth_pub = nh->advertise<sensor_msgs::Imu>(ground_truth_topic, 1);
-  noise_pub = nh->advertise<sensor_msgs::Imu>(noise_topic, 1);
+  ground_truth_pub = nh->advertise<sensor_msgs::Imu>("/accelerometer/ground_truth", 1);
+  noise_pub = nh->advertise<sensor_msgs::Imu>("/accelerometer/data", 1);
 
   // Setup accelerometer device
   accelerometer = wb->getAccelerometer(accelerometer_name);

--- a/lib/sensors/src/gps.cpp
+++ b/lib/sensors/src/gps.cpp
@@ -20,18 +20,14 @@ GPS::GPS(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle)
   nh->param<std::string>("gps/name", gps_name, "gps");
   nh->param<std::string>("gps/frame_id", frame_id, "gps");
   nh->param("gps/sampling_period", sampling_period, 32);
-  nh->param<std::string>("gps/gt_coordinate_topic", gt_coordinate_topic,
-                         "/gps/ground_truth/coordinates");
-  nh->param<std::string>("gps/coordinate_topic", coordinate_topic,
-                         "/gps/coordinates");
   nh->param("gps/noise_mean", noise_mean, 0.0);
   nh->param("gps/noise_std", noise_std, 0.15);
   nh->param("gps/noise_seed", noise_seed, 17);
 
   // Create publishers
   gt_coordinate_pub =
-      nh->advertise<sensor_msgs::NavSatFix>(gt_coordinate_topic, 1);
-  coordinate_pub = nh->advertise<sensor_msgs::NavSatFix>(coordinate_topic, 1);
+      nh->advertise<sensor_msgs::NavSatFix>("/gps/ground_truth/coordinates", 1);
+  coordinate_pub = nh->advertise<sensor_msgs::NavSatFix>("/gps/coordinates", 1);
 
   // Setup GPS device
   gps = wb->getGPS(gps_name);

--- a/lib/sensors/src/gyro.cpp
+++ b/lib/sensors/src/gyro.cpp
@@ -17,16 +17,13 @@ Gyro::Gyro(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle)
   nh->param<std::string>("gyro/name", gyro_name, "gyro");
   nh->param<std::string>("gyro/frame_id", frame_id, "gyro");
   nh->param("gyro/sampling_period", sampling_period, 32);
-  nh->param<std::string>("gyro/ground_truth_topic", ground_truth_topic,
-                         "/gyro/ground_truth");
-  nh->param<std::string>("gyro/noise_topic", noise_topic, "/gyro/data");
   nh->param("gyro/noise_mean", noise_mean, 0.0);
   nh->param("gyro/noise_std", noise_std, 0.0002);
   nh->param<int>("gyro/noise_seed", noise_seed, 17);
 
   // Create publishers
-  ground_truth_pub = nh->advertise<sensor_msgs::Imu>(ground_truth_topic, 1);
-  noise_pub = nh->advertise<sensor_msgs::Imu>(noise_topic, 1);
+  ground_truth_pub = nh->advertise<sensor_msgs::Imu>("/gyro/ground_truth", 1);
+  noise_pub = nh->advertise<sensor_msgs::Imu>("/gyro/data", 1);
 
   // Setup IMU device
   gyro = wb->getGyro(gyro_name);

--- a/lib/sensors/src/inertialUnit.cpp
+++ b/lib/sensors/src/inertialUnit.cpp
@@ -20,16 +20,13 @@ InertialUnit::InertialUnit(webots::Supervisor *webots_supervisor,
   nh->param<std::string>("imu/name", imu_name, "imu");
   nh->param<std::string>("imu/frame_id", frame_id, "imu");
   nh->param("imu/sampling_period", sampling_period, 32);
-  nh->param<std::string>("imu/ground_truth_topic", ground_truth_topic,
-                         "/imu/ground_truth");
-  nh->param<std::string>("imu/noise_topic", noise_topic, "/imu/data");
   nh->param("imu/noise_mean", noise_mean, 0.0);
   nh->param("imu/noise_std", noise_std, 0.02);
   nh->param<int>("imu/noise_seed", noise_seed, 17);
 
   // Create publishers
-  ground_truth_pub = nh->advertise<sensor_msgs::Imu>(ground_truth_topic, 1);
-  noise_pub = nh->advertise<sensor_msgs::Imu>(noise_topic, 1);
+  ground_truth_pub = nh->advertise<sensor_msgs::Imu>("/imu/ground_truth", 1);
+  noise_pub = nh->advertise<sensor_msgs::Imu>("/imu/data", 1);
 
   // Setup IMU device
   imu = wb->getInertialUnit(imu_name);

--- a/lib/sensors/src/lidar.cpp
+++ b/lib/sensors/src/lidar.cpp
@@ -21,17 +21,14 @@ Lidar::Lidar(webots::Supervisor *webots_supervisor,
   nh->param<std::string>("lidar/name", lidar_name, "RobotisLds01");
   nh->param<std::string>("lidar/frame_id", frame_id, "lidar");
   nh->param("lidar/sampling_period", sampling_period, 32);
-  nh->param<std::string>("lidar/ground_truth_topic", ground_truth_topic,
-                         "/lidar/ground_truth");
-  nh->param<std::string>("lidar/noise_topic", noise_topic, "/lidar/data");
   nh->param("lidar/noise_mean", noise_mean, 0.0);
   nh->param("lidar/noise_std", noise_std, 0.01);
   nh->param<int>("lidar/noise_seed", noise_seed, 17);
 
   // Create publishers
   ground_truth_pub =
-      nh->advertise<sensor_msgs::LaserScan>(ground_truth_topic, 1);
-  noise_pub = nh->advertise<sensor_msgs::LaserScan>(noise_topic, 1);
+      nh->advertise<sensor_msgs::LaserScan>("/lidar/ground_truth", 1);
+  noise_pub = nh->advertise<sensor_msgs::LaserScan>("/lidar/data", 1);
 
   // Setup LiDAR device
   lidar = wb->getLidar(lidar_name);

--- a/lib/sensors/src/wheelOdom.cpp
+++ b/lib/sensors/src/wheelOdom.cpp
@@ -20,8 +20,6 @@ WheelOdom::WheelOdom(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros
     nh->param<std::string>("wheel_odom/front_left_name", fl_name, "fl_odom");
     nh->param<std::string>("wheel_odom/frame_id", frame_id, "base_link");
     nh->param("wheel_odom/sampling_period", sampling_period, 32);
-    nh->param<std::string>("wheel_odom/ground_truth_topic", ground_truth_topic, "/wheel_odom/ground_truth");
-    nh->param<std::string>("wheel_odom/noise_topic", noise_topic, "/wheel_odom/data");
     nh->param("wheel_odom/noise_mean", noise_mean, 0.0);
     nh->param("wheel_odom/noise_std", noise_std, 0.002);
     nh->param<int>("wheel_odom/noise_seed", noise_seed, 17);
@@ -29,8 +27,8 @@ WheelOdom::WheelOdom(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros
     nh->param("wheel_radius", wheel_radius, 0.12);
 
     // Create publishers
-    ground_truth_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(ground_truth_topic, 1);
-    noise_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>(noise_topic, 1);
+    ground_truth_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>("/wheel_odom/ground_truth", 1);
+    noise_pub = nh->advertise<geometry_msgs::TwistWithCovarianceStamped>("/wheel_odom/data", 1);
 
     // Get wheel position sensors
     rr_odom = wb->getPositionSensor(rr_name);

--- a/lib/steering/include/steering/diffSteering.hpp
+++ b/lib/steering/include/steering/diffSteering.hpp
@@ -22,8 +22,6 @@ namespace AutomatED
 
     // ROS Parameters
     std::string frame_id;
-    std::string ground_truth_topic;
-    std::string noise_topic;
     double wheel_separation;
     double wheel_radius;
 

--- a/lib/steering/src/diffSteering.cpp
+++ b/lib/steering/src/diffSteering.cpp
@@ -15,10 +15,6 @@ DiffSteering::DiffSteering(std::vector<webots::Motor *> motors,
 
   // Get ROS parameters
   nh->param<std::string>("wheel_odom/frame_id", frame_id, "base_link");
-  nh->param<std::string>("wheel_odom/ground_truth_topic", ground_truth_topic,
-                         "/wheel_odom/ground_truth");
-  nh->param<std::string>("wheel_odom/noise_topic", noise_topic,
-                         "/wheel_odom/data");
   nh->param("wheel_separation", wheel_separation, 0.6);
   nh->param("wheel_radius", wheel_radius, 0.12);
 


### PR DESCRIPTION
This PR removes the parameters that are used to determine the topics a node publishers/subscribes to. This is because we can use [`<remap>` statements](https://wiki.ros.org/roslaunch/XML/remap) in the launch files to achieve the same thing but without any of the extra code.