### PR TITLE
Add ground truth pose publisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ add_library(sensors
     lib/sensors/src/wheelOdom.cpp
 )
 add_library(steering lib/steering/src/diffSteering.cpp)
-add_library(utils lib/utils/src/KeyboardController.cpp)
+add_library(utils lib/utils/src/KeyboardController.cpp lib/utils/src/GroundTruthPose.cpp)
 target_link_libraries(sensors ${WEBOTS_LIB} ${catkin_LIBRARIES})
 target_link_libraries(steering ${WEBOTS_LIB} ${catkin_LIBRARIES})
 target_link_libraries(utils ${WEBOTS_LIB} ${catkin_LIBRARIES})

--- a/lib/utils/include/utils/GroundTruthPose.hpp
+++ b/lib/utils/include/utils/GroundTruthPose.hpp
@@ -1,0 +1,35 @@
+#include "ros/ros.h"
+#include "nav_msgs/Odometry.h"
+#include "webots/Supervisor.hpp"
+
+namespace AutomatED
+{
+
+    class GroundTruthPose
+    {
+    public:
+        GroundTruthPose(webots::Supervisor *webots_supervisor,
+                        ros::NodeHandle *ros_handle);
+        ~GroundTruthPose();
+
+        void publishPose();
+
+    private:
+        // Handlers
+        webots::Supervisor *wb_;
+        ros::NodeHandle *nh_;
+
+        // ROS Parameters
+        std::string robot_name_;
+        int frequency_;
+        std::string frame_id_;
+
+        // ROS Publisher
+        ros::Publisher pose_pub_;
+
+        // Robot parameters
+        webots::Node *robot_;
+        double *start_pos_;
+    };
+
+} // namespace AutomatED

--- a/lib/utils/src/GroundTruthPose.cpp
+++ b/lib/utils/src/GroundTruthPose.cpp
@@ -1,0 +1,48 @@
+#include "utils/GroundTruthPose.hpp"
+
+using namespace AutomatED;
+
+GroundTruthPose::GroundTruthPose(webots::Supervisor *webots_supervisor, ros::NodeHandle *ros_handle)
+{
+    // Handlers
+    wb_ = webots_supervisor;
+    nh_ = ros_handle;
+
+    // ROS Parameters
+    nh_->param<std::string>("ground_truth_pose/robot_name", robot_name_, "StreetSmart");
+    nh_->param("ground_truth_pose/frequency", frequency_, 30);
+    nh_->param<std::string>("ground_truth_pose/frame_id", frame_id_, "map");
+
+    // ROS Publisher
+    pose_pub_ = nh_->advertise<nav_msgs::Odometry>("/ground_truth/pose", 1);
+
+    // Get starting position of robot
+    robot_ = wb_->getSelf();
+    start_pos_ = new double[3];
+    start_pos_[0] = robot_->getPosition()[0];
+    start_pos_[1] = robot_->getPosition()[1];
+    start_pos_[2] = robot_->getPosition()[2];
+}
+
+GroundTruthPose::~GroundTruthPose()
+{
+    pose_pub_.shutdown();
+}
+
+void GroundTruthPose::publishPose()
+{
+    // Get position of robot from starting position
+    double *cur_pos = new double[3];
+    cur_pos[0] = robot_->getPosition()[0] - start_pos_[0];
+    cur_pos[1] = robot_->getPosition()[1] - start_pos_[1];
+    cur_pos[2] = robot_->getPosition()[2] - start_pos_[2];
+
+    nav_msgs::Odometry msg;
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = frame_id_;
+    msg.pose.pose.position.x = cur_pos[2];
+    msg.pose.pose.position.y = cur_pos[0];
+    msg.pose.pose.position.z = cur_pos[1];
+
+    pose_pub_.publish(msg);
+}

--- a/src/full_controller.cpp
+++ b/src/full_controller.cpp
@@ -7,6 +7,7 @@
 #include "sensors/wheelOdom.hpp"
 #include "steering/diffSteering.hpp"
 #include "utils/KeyboardController.hpp"
+#include "utils/GroundTruthPose.hpp"
 #include "webots/Motor.hpp"
 #include "webots/LED.hpp"
 #include "webots/Supervisor.hpp"
@@ -47,6 +48,9 @@ int main(int argc, char **argv)
   // Instantiate steering
   AutomatED::DiffSteering diffSteering = AutomatED::DiffSteering(motors, &nh);
 
+  // Instantiate ground truth pose
+  AutomatED::GroundTruthPose groundTruthPose = AutomatED::GroundTruthPose(supervisor, &nh);
+
   // Instaniate keyboard steering
   AutomatED::KeyboardController *keyboard;
   if (use_keyboard_control)
@@ -68,6 +72,7 @@ int main(int argc, char **argv)
     gyro.publishGyro();
     accelerometer.publishAccelerometer();
     wheel_odom.publishWheelOdom();
+    groundTruthPose.publishPose();
 
     if (use_keyboard_control)
     {


### PR DESCRIPTION
This PR adds a component to the `full_controller` called `GroundTruthPose` that takes the position of the robot directly from simulation and publishes an `nav_msgs/Odom` message with the position of the robot in the map frame.

The ground truth data is published to `/ground_truth/pose` as set in https://github.com/automat-ed/autonomous/pull/29.

~~**Note: it would be good if someone could double check the `x`, `y` and `z` values of the position that the `GroundTruthPose` class publishes as it wasn't what I expected it to be**~~. To come up with the transformation of the data, I used the plot generated from https://github.com/automat-ed/autonomous/pull/29:

![fig](https://user-images.githubusercontent.com/38025909/111893966-989c2300-89fe-11eb-99da-63da772fee61.png)
